### PR TITLE
es: tune down excessive send failure messages

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -289,7 +289,7 @@ class ElasticsearchSender(LogSender):
                 self.log.info("Sent %d metrics to ES, took: %.2fs",
                               len(message_batch), time.monotonic() - start_time)
         except Exception as ex:  # pylint: disable=broad-except
-            self.log.warning("Problem sending logs to ES: %r", ex)
+            self.log.warning("Problem sending logs to ES: %s", ex.__class__.__name__)
             return False
         return True
 


### PR DESCRIPTION
ElasticSearch send failure messages can be rather on the
excessive side when str(ex) formatted (30KiB). Log just the
exception class name.