### PR TITLE
Move away from deprecated SimpleProducer/SimpleClient

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -191,8 +191,9 @@ class KafkaSender(LogSender):
 
         self.kafka_producer = None
 
-        if not isinstance(self.config["kafka_topic"], bytes):
-            topic = self.config["kafka_topic"].encode("utf8")
+        topic = self.config["kafka_topic"]
+        if isinstance(self.config["kafka_topic"], bytes):
+            topic = topic.decode("utf8")
         self.topic = topic
 
     def _init_kafka(self):

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -196,7 +196,7 @@ class KafkaSender(LogSender):
         self.topic = topic
 
     def _init_kafka(self):
-        self.log.info("Initializing Kafka client, address: %r", self.config["kafka_address"])
+        self.log.info("Initializing Kafka producer, address: %r", self.config["kafka_address"])
         while self.running:
             try:
                 if self.kafka_producer:
@@ -212,7 +212,7 @@ class KafkaSender(LogSender):
 
                 self.kafka_producer = KafkaProducer(**producer_config)
 
-                self.log.info("Initialized Kafka Client, address: %r", self.config["kafka_address"])
+                self.log.info("Initialized Kafka producer, address: %r", self.config["kafka_address"])
                 break
             except KAFKA_CONN_ERRORS as ex:
                 self.log.warning("Retriable error during Kafka initialization: %s: %s, sleeping",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+elasticsearch
+kafka-python==1.1.1
+requests

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,16 @@ from setuptools import setup, find_packages
 from journalpump import __version__
 import os
 
+with open("requirements.txt") as fp:
+    reqs = fp.read().splitlines()
+
 setup(
     name="journalpump",
     version=os.getenv("VERSION") or __version__,
     zip_safe=False,
     packages=find_packages(exclude=["test"]),
     extras_require={},
+    install_requires=reqs,
     dependency_links=[],
     package_data={},
     data_files=[],


### PR DESCRIPTION
I've also enforced requirements.

This should work properly with with kafka-python 1.1.1 (I've run this locally on a fresh Ubuntu 16.04 install).