### PR TITLE
journalpump: multiple readers and senders

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+journalpump 2.1.x (unreleased)
+==============================
+* Support for multiple journal readers with separate configuration for each
+* Multiple send destinations per reader
+* Reader flags can be specified to for example read the "system" journal
+
 journalpump 2.0.0 (2017-02-13)
 ============================
 

--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,14 @@ default one.
 Require that the logs message matches only against certain _SYSTEMD_UNITs.
 If not set, we allow log events from all units.
 
+``flags`` (default ``LOCAL_ONLY``)
+
+``"LOCAL_ONLY"`` opens journal on local machine only; ``"RUNTIME_ONLY"`` opens only volatile journal files;
+and ``"SYSTEM"`` opens journal files of system services and the kernel, ``"CURRENT_USER"`` opens files of the
+current user; and ``"OS_ROOT"`` is used to open the journal from directories relative to the specified
+directory path or file descriptor. Multiple flags can be OR'ed together using a list:
+``["LOCAL_ONLY", "CURRENT_USER"]``.
+
 
 Sender Configuration
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,14 @@ Example configuration for a single reader::
   }
 
 
+``initial_position`` (default ``head``)
+
+Controls where the readers starts when the journalpump is launched for the first time:
+
+* ``head``: First entry in the journal
+* ``tail``: Last entry in the journal
+* ``<integer>``: Seconds from current boot session
+
 ``match_key`` (default ``null``)
 
 If you want to match against a single journald field, this configuration key

--- a/journalpump.json
+++ b/journalpump.json
@@ -1,13 +1,38 @@
 {
-    "output_type": "elasticsearch",
-    "elasticsearch_url": "https://u9r6z9e8:er57mbtcgsxn4lya@machinedomain.com:18195",
-    "elasticsearch_index_prefix": "journalpump",
-    "ca": "path/to/ca/file",
-    "certfile": "path/to/cert",
-    "keyfile": "path/to/key",
-    "ssl": true,
-    "kafka_topic": "testtopic",
-    "kafka_address": "localhost",
-    "match_key": "_MACHINE_ID",
-    "match_value": "97baf08d-62a5-47a6-9ce3-cd3b6685d3ec"
+    "readers": {
+        "host1": {
+            "senders": {
+                "__doc__": "Example: sending a single reader's output to multiple destinations",
+                "elastic1": {
+                    "output_type": "elasticsearch",
+                    "elasticsearch_url": "https://u9r6z9e8:er57mbtcgsxn4lya@machinedomain.com:18195",
+                    "elasticsearch_index_prefix": "journalpump",
+                    "ca": "path/to/ca/file",
+                    "certfile": "path/to/cert",
+                    "keyfile": "path/to/key",
+                    "ssl": true,
+                },
+                "kafka1": {
+                    "output_type": "kafka",
+                    "kafka_topic": "testtopic",
+                    "kafka_address": "localhost",
+                    "match_key": "_MACHINE_ID",
+                    "match_value": "97baf08d-62a5-47a6-9ce3-cd3b6685d3ec"
+                }
+            }
+        },
+        "sshd": {
+            "__doc__": "Example: sending just the sshd service logs (requires flags=4, i.e. systemd.journal.SYSTEM)",
+            "flags": 4,
+            "units_to_match": [
+                "sshd.service"
+            ],
+            "senders": {
+                "logfile1": {
+                    "output_type": "file",
+                    "file_output": "/tmp/sshd.log"
+                }
+            }
+        }
+    }
 }

--- a/journalpump/statsd.py
+++ b/journalpump/statsd.py
@@ -41,7 +41,7 @@ class StatsClient(object):
         parts = [metric.encode("utf-8"), b":", str(value).encode("utf-8"), b"|", metric_type]
         send_tags = self._tags.copy()
         send_tags.update(tags or {})
-        for tag, value in send_tags.items():
-            parts.insert(1, ",{}={}".format(tag, value).encode("utf-8"))
+        for tag, tag_value in send_tags.items():
+            parts.insert(1, ",{}={}".format(tag, tag_value).encode("utf-8"))
 
         self._socket.sendto(b"".join(parts), self._dest_addr)

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -6,39 +6,80 @@ def test_journalpump_init(tmpdir):
     # Logplex sender
     journalpump_path = str(tmpdir.join("journalpump.json"))
     config = {
-        "logplex_token": "foo",
-        "logplex_log_input_url": "http://logplex.com",
-        "output_type": "logplex"
+        "readers": {
+            "foo": {
+                "senders": {
+                    "bar": {
+                        "logplex_token": "foo",
+                        "logplex_log_input_url": "http://logplex.com",
+                        "output_type": "logplex",
+                    },
+                },
+            },
+        },
     }
+
     with open(journalpump_path, "w") as fp:
         fp.write(json.dumps(config))
     a = JournalPump(journalpump_path)
-    a.initialize_sender()
-    a.sender.running = False
-    assert isinstance(a.sender, LogplexSender)
+
+    for rn, r in a.readers.items():
+        assert rn == "foo"
+        r.running = False
+        for sn, s in r.senders.items():
+            assert sn == "bar"
+            s.running = False
+            assert isinstance(s, LogplexSender)
 
     # Kafka sender
     config = {
-        "output_type": "kafka",
-        "logplex_token": "foo",
-        "kafka_address": "localhost",
-        "kafka_topic": "foo"}
-    with open(journalpump_path, "w") as fp:
-        fp.write(json.dumps(config))
-    a = JournalPump(journalpump_path)
-    a.initialize_sender()
-    a.sender.running = False
-    assert isinstance(a.sender, KafkaSender)
-
-    # Elasticsearch sender
-    config = {
-        "output_type": "elasticsearch",
-        "elasticsearch_url": "https://foo.aiven.io",
-        "elasticsearch_index_prefix": "fooprefix",
+        "readers": {
+            "foo": {
+                "senders": {
+                    "bar": {
+                        "output_type": "kafka",
+                        "logplex_token": "foo",
+                        "kafka_address": "localhost",
+                        "kafka_topic": "foo",
+                    },
+                },
+            },
+        },
     }
     with open(journalpump_path, "w") as fp:
         fp.write(json.dumps(config))
     a = JournalPump(journalpump_path)
-    a.initialize_sender()
-    a.sender.running = False
-    assert isinstance(a.sender, ElasticsearchSender)
+
+    for rn, r in a.readers.items():
+        assert rn == "foo"
+        r.running = False
+        for sn, s in r.senders.items():
+            assert sn == "bar"
+            s.running = False
+            assert isinstance(s, KafkaSender)
+
+    # Elasticsearch sender
+    config = {
+        "readers": {
+            "foo": {
+                "senders": {
+                    "bar": {
+                        "output_type": "elasticsearch",
+                        "elasticsearch_url": "https://foo.aiven.io",
+                        "elasticsearch_index_prefix": "fooprefix",
+                    },
+                },
+            },
+        },
+    }
+    with open(journalpump_path, "w") as fp:
+        fp.write(json.dumps(config))
+    a = JournalPump(journalpump_path)
+
+    for rn, r in a.readers.items():
+        assert rn == "foo"
+        r.running = False
+        for sn, s in r.senders.items():
+            assert sn == "bar"
+            s.running = False
+            assert isinstance(s, ElasticsearchSender)


### PR DESCRIPTION
NOTE: This is a backward breaking change for the json configuration file
format!

* Multiple "readers" can be operated in a single journalpump process
* Each reader has its own input settings (source file, flags, metrics
  tags, etc.)
* One reader can have zero or more "senders", i.e. the same journal
  entries can be sent to multiple destinations (e.g. log file + Kafka)

Smaller changes:

* StatsD output is buffered, making overall performance somewhat better
* More extensive progress stats are written to the output stats file
* Output stats file is disabled unless explicitly enabled in the json
  configuration file