### PR TITLE
Allow filtering journald fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,9 @@ Top level configuration
 Example::
 
   {
+      "field_filters": {
+         ...
+      },
       "json_state_file_path": "/var/lib/journalpump/journalpump_state.json",
       "readers": {
          ...
@@ -132,6 +135,35 @@ Metrics sending follows the `Telegraf spec`_.
 
 Determines log level of journalpump.
 
+Field filter configuration
+==========================
+
+Field filters can be used to restrict the journald fields that journalpump sends forward.
+Field filter configuration structure::
+
+  {
+      "field_filters": {
+          "filter_name": {
+              "type": "whitelist|blacklist",
+              "fields": ["field1", "field2"]
+          }
+      }
+  }
+
+``filter_name``
+
+Name of the filter. The filters can be configured per sender and depending
+on the use case the filters for different senders may vary.
+
+``type`` (default ``whitelist``)
+
+Specifies whether the listed fields will be included (``whitelist``) or
+excluded (``blacklist``).
+
+``fields``
+
+The actual fields to include or exclude. Field name matching is case
+insensitive and underscores in the beginning of the fields are trimmed.
 
 Reader configuration
 ====================
@@ -162,10 +194,17 @@ Reader configuration structure::
 Example configuration for a single reader::
 
   {
+      "field_filters": {
+          "drop_process_id": {
+              "fields": ["process_id"],
+              "type": "blacklist"
+          }
+      },
       "journal_path": "/var/lib/machines/container1/var/log/journal/b09ffd62229f4bd0829e883c6bb12c4e",
       "senders": {
           "k1": {
               "output_type": "kafka",
+              "field_filter": "drop_process_id",
               "ca": "/etc/journalpump/ca-bundle.crt",
               "certfile": "/etc/journalpump/node.crt",
               "kafka_address": "kafka.somewhere.com:12345",
@@ -236,6 +275,10 @@ Sender Configuration
 
 Output to write journal events to.  Options are `elasticsearch`, `kafka`,
 `file` and `logplex`.
+
+``field_filter`` (default ``null``)
+
+Name of the field filter to apply for this sender, if any.
 
 
 File Sender Configuration

--- a/journalpump.json
+++ b/journalpump.json
@@ -1,4 +1,19 @@
 {
+    "field_filters": {
+        "drop_selinux_context": {
+            "fields": [
+                "_SELINUX_CONTEXT"
+            ],
+            "type": "blacklist"
+        },
+        "include_message_and_machine_id": {
+            "fields": [
+                "MESSAGE",
+                "_MACHINE_ID"
+            ],
+            "type": "whitelist"
+        }
+    },
     "readers": {
         "host1": {
             "senders": {
@@ -11,13 +26,15 @@
                     "certfile": "path/to/cert",
                     "keyfile": "path/to/key",
                     "ssl": true,
+                    "field_filter": "drop_selinux_context"
                 },
                 "kafka1": {
                     "output_type": "kafka",
                     "kafka_topic": "testtopic",
                     "kafka_address": "localhost",
                     "match_key": "_MACHINE_ID",
-                    "match_value": "97baf08d-62a5-47a6-9ce3-cd3b6685d3ec"
+                    "match_value": "97baf08d-62a5-47a6-9ce3-cd3b6685d3ec",
+                    "field_filter": "include_message_and_machine_id"
                 }
             }
         },


### PR DESCRIPTION
Previously all fields read from journald were always sent forward. There
are typically quite a few fields that are not interesting for specific
use cases and sending them just creates bloat.

A new field filter configuration is now supported and each sender may be
associated with a specific filter. If a sender doesn't have associated
field filter it behaves like before (sends all fields), otherwise the
appropriate filter is applied before the entry data is serialized. To
support the sender specific filtering (and to allow easier testing of
just part of the logic) the journal object processing was refactored to
a class of its own.

Both whitelist and blacklist field filters are supported. Whitelist
filters only include the explicitly specified fields while blacklist
filters only exclude the explicitly specified fields. Field name
matching ignores underscores in the beginning of the name and is case
insensitive.