### PR TITLE
Address lintian errors and some warnings

### DIFF
--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -3,7 +3,7 @@ journalpump (1.0.1) unstable; urgency=low
   * Rename to journalpump
   * Require Python 3
 
- -- Oskari Saarenmaa <os@aivenio>  Fri, 25 Mar 2016 11:50:01 +0200
+ -- Oskari Saarenmaa <os@aiven.io>  Fri, 25 Mar 2016 11:50:01 +0200
 
 kafkajournalpump (1.0.0) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -11,10 +11,10 @@ Homepage: https://github.com/aiven/journalpump
 
 Package: journalpump
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends},
+Depends: ${misc:Depends}, ${python3:Depends}, adduser,
  python3-elasticsearch, python3-kafka,
  python3-requests, python3-systemd
-Description: journalpump is a daemon that takes log messages from journald and pumps them
+Description: daemon that takes log messages from journald and pumps them
  to a given output.  Currently supported outputs are Elasticsearch, Kafka and
  logplex.  It reads messages from journald and optionally checks if they
  match a config rule and forwards them as JSON messages to the desired

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,1 +1,7 @@
-adduser --quiet --system --group --home /var/lib/journalpump journalpump
+#!/bin/sh
+
+set -e
+
+if ! getent passwd journalpump >/dev/null; then
+        adduser --quiet --system --group --home /var/lib/journalpump journalpump
+fi

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -62,7 +62,7 @@ def convert_realtime(t):
 def default_json_serialization(obj):  # pylint: disable=inconsistent-return-statements
     if isinstance(obj, bytes):
         return obj.decode("utf8")
-    elif isinstance(obj, datetime.datetime):
+    if isinstance(obj, datetime.datetime):
         return obj.isoformat()
 
 
@@ -1009,7 +1009,7 @@ class JournalPump(ServiceDaemon, Tagged):
     def check_match(self, entry):
         if not self.config.get("match_key"):
             return True
-        elif entry.get(self.config["match_key"]) == self.config["match_value"]:
+        if entry.get(self.config["match_key"]) == self.config["match_value"]:
             return True
         return False
 

--- a/journalpump/statsd.py
+++ b/journalpump/statsd.py
@@ -9,7 +9,7 @@ Supports telegraf's statsd protocol extension for 'key=value' tags:
 import socket
 
 
-class StatsClient(object):
+class StatsClient:
     def __init__(self, host="127.0.0.1", port=8125, tags=None):
         self._dest_addr = (host, port)
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
This addresses all errors indicated by `lintian` and warnings other than:

```W: journalpump: binary-without-manpage usr/bin/journalpump```

I don't know if modifying the email address after-the-fact is kosher. That change can be easily dropped if so desired.