### PR TITLE
Use journald API more appropriately, limit log messages to keep in memory

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -210,7 +210,7 @@ class LogSender(Thread, Tagged):
 
     def get_and_send_messages(self):
         start_time = time.monotonic()
-        messages = None
+        msg_count = None
         try:
             messages = self.msg_buffer.get_items()
             msg_count = len(messages)
@@ -241,7 +241,7 @@ class LogSender(Thread, Tagged):
             self.log.debug("Sending %d msgs, took %.4fs", msg_count, time.monotonic() - start_time)
             self.last_send_time = time.monotonic()
         except Exception:   # pylint: disable=broad-except
-            self.log.exception("Problem sending messages: %r", messages)
+            self.log.exception("Problem sending %r messages", msg_count)
             time.sleep(0.5)
 
 


### PR DESCRIPTION
Previously journald API was not used as the documentation suggests, which caused it to stop returning log messages after log rotation and possibly in some other cases as well. Switched to polling file descriptors so that we can react immediately and added the process call that is required to cope with any non-append operations.

Also changes the logic related to enforcing maximum number of messages that are kept in memory. The old implementation already had a variable controlling how many messages should be kept in memory at most but the implementation was nonsensical. Instead of doing anything to restrict the in-memory messages it slowed down message sending away from the node, which just made the problem worse. Now the journal reader is completely disabled when too many messages are in memory and resumed only after number of messages is again below the threshold.