### PR TITLE
reader: if set, only pass through messages that match searches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
-dist: trusty
+dist: xenial
 
 before_install:
   - "sudo apt-get update"
-  - "sudo apt-get install -y libsystemd-journal-dev libsystemd-daemon-dev libsystemd-login-dev"
+  - "sudo apt-get install -y libsystemd-dev"
 
 python:
   - "3.4"

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -1000,11 +1000,13 @@ class JournalObjectHandler:
             else:
                 new_entry[key.lstrip("_")] = value
 
-        self.reader.perform_searches(self.jobject)
-
         if self.jobject.cursor is None:
             self.log.debug("No more journal entries to read")
             return False
+
+        if self.reader.searches:
+            if not self.reader.perform_searches(self.jobject):
+                return True
 
         if not self.pump.check_match(new_entry):
             return True


### PR DESCRIPTION
If searches have been defined for a given reader, only pass through messages that match those searches to senders. This allows one to output a selection of the captured messages to readers.

Previous behavior of passing full incoming stream and doing stats on searches can be accomplished by configuring two readers the searches on the first and the senders on the latter.