### PR TITLE
Add missing timeouts for requests HTTP calls

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 journalpump 2.1.3 (unreleased)
 ==============================
 * Use atomic replacement when overwriting previous state file
+* Add missing timeout to Elasticsearch log sender
 
 journalpump 2.1.2 (2019-10-11)
 ==============================


### PR DESCRIPTION
The requests library by default uses indefinite timeout, which may cause
calls to block forever. The Elasticsearch code was missing timeouts from
a couple of places, which potentially caused sender thread to hang.

Also start using an adapter that explicitly sets some timeout so that
new calls added in the future don't accidentally omit the timeout.