### PR TITLE
elasticsearch: fix es index deletion logic

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -552,7 +552,8 @@ class ElasticsearchSender(LogSender):
 
     def check_indices(self):
         aliases = self.session.get(self.session_url + "/_aliases", timeout=60.0).json()
-        indices = [key for key in aliases.keys() if key.startswith(self.index_name)]
+        index_full_prefix = "{}-".format(self.index_name)
+        indices = sorted(key for key in aliases.keys() if key.startswith(index_full_prefix))
         self.log.info("Checking indices, currently: %r are available, max_indices: %r", indices, self.index_days_max)
         while len(indices) > self.index_days_max:
             index_to_delete = indices.pop(0)

--- a/journalpump/util.py
+++ b/journalpump/util.py
@@ -28,7 +28,7 @@ class TimeoutAdapter(requests.adapters.HTTPAdapter):
         self.timeout = timeout
         super(TimeoutAdapter, self).__init__(*args, **kwargs)
 
-    def send(self, *args, **kwargs):  # pylint: disable=arguments-differ
+    def send(self, *args, **kwargs):  # pylint: disable=arguments-differ,signature-differs
         if not kwargs.get("timeout"):
             kwargs["timeout"] = self.timeout
         return super(TimeoutAdapter, self).send(*args, **kwargs)


### PR DESCRIPTION
The index deletion expects the list to only contain indexes created
by journalpump and fails if the list contains indexes that start
with the prefix, but are not actually created by journalpump
(logs- vs logstash).