### PR TITLE
aws_cloudwatch: added sender for aws cloudwatch logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "3.7"
 
 install:
-  - "pip install pylint pytest mock flake8 kafka-python coverage coveralls requests responses"
+  - "pip install pylint pytest mock flake8 kafka-python coverage coveralls requests responses boto3"
   - "pip install https://github.com/systemd/python-systemd/zipball/master"
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ rpm:
 build-dep-fed:
 	sudo dnf -y --best --allowerasing install \
 		python3-flake8 python3-kafka python3-pytest python3-pylint \
-		python3-requests python3-responses systemd-python3
+		python3-requests python3-responses systemd-python3 python3-boto3
 
 build-dep-deb:
 	sudo apt-get install \

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+journalpump 2.2.0 (2020-06-01)
+==============================
+* Added AWS CloudWatch logs sender
+
 journalpump 2.1.3 (2019-10-30)
 ==============================
 * Use atomic replacement when overwriting previous state file

--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,9 @@ journalpump |BuildStatus|_
 
 journalpump is a daemon that takes log messages from journald and pumps them
 to a given output.  Currently supported outputs are Elasticsearch, Kafka,
-logplex and rsyslog. It reads messages from journald and optionally checks if they
-match a config rule and forwards them as JSON messages to the desired
-output.
+logplex, rsyslog and AWS CloudWatch. It reads messages from journald and
+optionally checks if they match a config rule and forwards them as JSON messages
+to the desired output.
 
 
 Building
@@ -355,6 +355,34 @@ for partition selection.
 Kafka client key path, needed when you're using Kafka with SSL
 authentication.
 
+AWS CloudWatch Logs Sender Configuration
+----------------------------------------
+``aws_cloudwatch_log_group``
+
+The log group used in AWS CloudWatch.
+
+``aws_cloudwatch_log_stream``
+
+The log stream used in AWS CloudWatch.
+
+``aws_region`` (default ``null``)
+
+AWS region used.
+
+``aws_access_key_id`` (default ``null``)
+
+AWS access key id used.
+
+``aws_secret_access_key`` (default ``null``)
+
+AWS secret access key used.
+
+The AWS credentials and region are optional. In case they are not included
+credentials are configured automatically by the ``boto3`` module.
+
+The AWS credentials that are used need the following permissions:
+``logs:CreateLogGroup``, ``logs:CreateLogStream``, ``logs:PutLogEvents``
+and ``logs:DescribeLogStreams``.
 
 Rsyslog Sender Configuration
 ----------------------------

--- a/debian/control
+++ b/debian/control
@@ -13,9 +13,10 @@ Package: journalpump
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, adduser,
  python3-elasticsearch, python3-kafka,
- python3-requests, python3-systemd
+ python3-requests, python3-systemd,
+ python3-boto3
 Description: daemon that takes log messages from journald and pumps them
- to a given output.  Currently supported outputs are Elasticsearch, Kafka and
- logplex.  It reads messages from journald and optionally checks if they
- match a config rule and forwards them as JSON messages to the desired
- output.
+ to a given output.  Currently supported outputs are Elasticsearch, Kafka,
+ logplex and AWS CloudWatch.  It reads messages from journald and optionally
+ checks if they match a config rule and forwards them as JSON messages to
+ the desired output.

--- a/journalpump.spec
+++ b/journalpump.spec
@@ -2,20 +2,20 @@ Name:           journalpump
 Version:        %{major_version}
 Release:        %{minor_version}%{?dist}
 Url:            http://github.com/aiven/journalpump
-Summary:        Pump messages from systemd journal to Elasticsearch, Kafka or Logplex
+Summary:        Pump messages from systemd journal to Elasticsearch, Kafka, Logplex or AWS CloudWatch
 License:        ASL 2.0
 Source0:        journalpump-rpm-src.tar.gz
-Requires:       python3-kafka, systemd-python3, python3-requests
-BuildRequires:  python3-kafka, systemd-python3, python3-requests
+Requires:       python3-kafka, systemd-python3, python3-requests, python3-boto3
+BuildRequires:  python3-kafka, systemd-python3, python3-requests, python3-boto3
 BuildRequires:  python3-devel, python3-pytest, python3-pylint python3-responses
 BuildArch:      noarch
 Obsoletes:      kafkajournalpump
 
 %description
 journalpump is a daemon that takes log messages from journald and pumps them
-to a given output.  Currently supported outputs are Elasticsearch, Kafka and
-logplex.  It reads messages from journald and optionally checks if they
-match a config rule and forwards them as JSON messages to the desired
+to a given output.  Currently supported outputs are Elasticsearch, Kafka,
+logplex and AWS CloudWatch.  It reads messages from journald and optionally
+checks if they match a config rule and forwards them as JSON messages to the desired
 output.
 
 

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -25,6 +25,8 @@ import socket
 import systemd.journal
 import time
 import uuid
+import botocore
+import boto3
 
 try:
     import snappy
@@ -308,6 +310,93 @@ class LogSender(Thread, Tagged):
         except Exception:   # pylint: disable=broad-except
             self.log.exception("Problem sending %r messages", msg_count)
             self._backoff()
+
+
+class AWSCloudWatchSender(LogSender):
+    def __init__(self, *, config, aws_cloudwatch_logs=None, **kwargs):
+        super().__init__(
+            config=config,
+            max_send_interval=config.get("max_send_interval", 0.3),
+            **kwargs
+        )
+        self._logs = aws_cloudwatch_logs
+        self.log_group = self.config.get("aws_cloudwatch_log_group")
+        self.log_stream = self.config.get("aws_cloudwatch_log_stream")
+        self._next_sequence_token = None
+        self._init_logs()
+
+    def _init_logs(self):
+        if self._logs is None:
+            if self.log_group is None or self.log_stream is None:
+                raise Exception("AWS CloudWatch log group and stream names need to be configured")
+            kwargs = {}
+            if self.config.get("aws_region") is not None:
+                kwargs["region_name"] = self.config.get("aws_region")
+            if self.config.get("aws_access_key_id") is not None:
+                kwargs["aws_access_key_id"] = self.config.get("aws_access_key_id")
+            if self.config.get("aws_secret_access_key") is not None:
+                kwargs["aws_secret_access_key"] = self.config.get("aws_secret_access_key")
+            self._logs = boto3.client("logs", **kwargs)
+        # Create the log group and stream if they don't exist yet
+        try:
+            self._logs.create_log_group(logGroupName=self.log_group)
+        except botocore.exceptions.ClientError as err:
+            if err.response["Error"]["Code"] != "ResourceAlreadyExistsException":
+                raise
+        try:
+            self._logs.create_log_stream(logGroupName=self.log_group, logStreamName=self.log_stream)
+        except botocore.exceptions.ClientError as err:
+            if err.response["Error"]["Code"] != "ResourceAlreadyExistsException":
+                raise
+        streams = self._logs.describe_log_streams(logGroupName=self.log_group).get("logStreams")
+        if streams is not None:
+            stream_metadata = [stream for stream in streams if stream['logStreamName'] == self.log_stream][0]
+            self._next_sequence_token = stream_metadata.get("uploadSequenceToken")
+            self.mark_connected()
+        else:
+            raise Exception("AWS CloudWatch logs could not update sequence token")
+
+    def send_messages(self, *, messages, cursor):
+        log_events = []
+        for msg in messages:
+            raw_message = msg.decode("utf8")
+            message = json.loads(raw_message)
+            timestamp = message.get("REALTIME_TIMESTAMP") or time.time()
+            log_events.append(
+                {
+                    "timestamp": int(timestamp * 1000.0),
+                    "message": raw_message
+                }
+            )
+        kwargs = {
+            "logGroupName": self.log_group,
+            "logStreamName": self.log_stream,
+            "logEvents": log_events
+        }
+        if self._next_sequence_token is not None:
+            kwargs["sequenceToken"] = self._next_sequence_token
+        try:
+            response = self._logs.put_log_events(**kwargs)
+        except botocore.exceptions.ClientError as err:
+            err_code = err.response["Error"]["Code"]
+            err_msg = err.response["Error"]["Message"]
+            self.mark_disconnected()
+            self.log.error("Error sending events %r: %r", err_code, err_msg)
+            self.stats.unexpected_exception(ex=err, where="sender", tags=self.make_tags({"app": "journalpump"}))
+            self._backoff()
+            self._init_logs()
+        except Exception as ex:  # pylint: disable=broad-except
+            self.mark_disconnected(ex)
+            self.log.exception("Unexpected exception during send to AWS CloudWatch")
+            self.stats.unexpected_exception(ex=ex, where="sender", tags=self.make_tags({"app": "journalpump"}))
+            self._backoff()
+            self._init_logs()
+        else:
+            if 200 <= response["ResponseMetadata"]["HTTPStatusCode"] < 300:
+                self.mark_sent(messages=messages, cursor=cursor)
+                self._next_sequence_token = response["nextSequenceToken"]
+                return True
+        return False
 
 
 class KafkaSender(LogSender):
@@ -807,6 +896,7 @@ class JournalReader(Tagged):
             "logplex": LogplexSender,
             "file": FileSender,
             "rsyslog": RsyslogSender,
+            "aws_cloudwatch": AWSCloudWatchSender
         }
         for sender_name, sender_config in self.config.get("senders", {}).items():
             try:

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -43,6 +43,8 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
     assert len(a.readers) == 1
     for rn, r in a.readers.items():
         assert rn == "foo"
+        r.create_journald_reader_if_missing()
+        assert len(r.senders) == 1
         r.running = False
         for sn, s in r.senders.items():
             assert sn == "bar"
@@ -73,6 +75,8 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
     assert len(a.readers) == 1
     for rn, r in a.readers.items():
         assert rn == "foo"
+        r.create_journald_reader_if_missing()
+        assert len(r.senders) == 1
         r.running = False
         for sn, s in r.senders.items():
             assert sn == "bar"
@@ -100,6 +104,8 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
     assert len(a.readers) == 1
     for rn, r in a.readers.items():
         assert rn == "foo"
+        r.create_journald_reader_if_missing()
+        assert len(r.senders) == 1
         r.running = False
         for sn, s in r.senders.items():
             assert sn == "bar"
@@ -127,6 +133,8 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
     assert len(a.readers) == 1
     for rn, r in a.readers.items():
         assert rn == "foo"
+        r.create_journald_reader_if_missing()
+        assert len(r.senders) == 1
         r.running = False
         for sn, s in r.senders.items():
             assert sn == "bar"
@@ -170,6 +178,7 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
         assert rn == "foo"
         with mock.patch("boto3.client", new=MockCloudWatch()) as mock_client:
             r.create_journald_reader_if_missing()
+            assert len(r.senders) == 1
             mock_client.assert_called_once_with(
                 "logs",
                 region_name="us-east-1",


### PR DESCRIPTION
Adds a new sender for sending log events to AWS CloudWatch. It is possible to configure the log group and stream as well as the AWS region to be used for the sender. AWS credentials can be set in sender config. If credentials or region are left out they are configured by the `boto3` module.