### PR TITLE
google_cloud_logging: added google cloud logging sender

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "3.7"
 
 install:
-  - "pip install pylint pytest mock flake8 kafka-python coverage coveralls requests responses boto3"
+  - "pip install pylint pytest mock flake8 kafka-python coverage coveralls requests responses boto3 google-api-python-client oauth2client"
   - "pip install https://github.com/systemd/python-systemd/zipball/master"
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ unittest:
 systest:
 	$(PYTHON) -m pytest -vv systest/
 
+py-egg:
+	VERSION=$(shell git describe --tags) $(PYTHON) setup.py bdist_egg
+
 pylint:
 	$(PYTHON) -m pylint --rcfile .pylintrc $(PYLINT_DIRS)
 
@@ -45,12 +48,14 @@ rpm:
 build-dep-fed:
 	sudo dnf -y --best --allowerasing install \
 		python3-flake8 python3-kafka python3-pytest python3-pylint \
-		python3-requests python3-responses systemd-python3 python3-boto3
+		python3-requests python3-responses systemd-python3 python3-boto3 \
+		python3-google-api-client
 
 build-dep-deb:
 	sudo apt-get install \
 		build-essential devscripts dh-systemd \
-		python-all python-setuptools python3-systemd python3-kafka
+		python-all python-setuptools python3-systemd python3-kafka \
+		python3-boto python3-googleapi
 
 
 .PHONY: rpm

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+journalpump 2.3.0 (2020-06-15)
+==============================
+* Added Google Cloud Logging logs sender
+
 journalpump 2.2.0 (2020-06-01)
 ==============================
 * Added AWS CloudWatch logs sender

--- a/README.rst
+++ b/README.rst
@@ -384,6 +384,26 @@ The AWS credentials that are used need the following permissions:
 ``logs:CreateLogGroup``, ``logs:CreateLogStream``, ``logs:PutLogEvents``
 and ``logs:DescribeLogStreams``.
 
+Google Cloud Logging Sender Configuration
+-----------------------------------------
+``google_cloud_logging_project_id``
+
+The GCP project id to which logs will be sent.
+
+``google_cloud_logging_log_id``
+
+The log id to be used for this particular sender.
+
+``google_cloud_logging_resource_labels``
+
+A dictionary containing the labels added to the monitored resource.
+Find the allowed labels from https://cloud.google.com/monitoring/api/resources#tag_generic_node.
+
+``google_service_account_credentials``
+
+The service account credentials to be used for this sender. If not
+defined, the sender will try to find credentials from the system.
+
 Rsyslog Sender Configuration
 ----------------------------
 

--- a/debian/control
+++ b/debian/control
@@ -14,9 +14,9 @@ Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, adduser,
  python3-elasticsearch, python3-kafka,
  python3-requests, python3-systemd,
- python3-boto3
+ python3-boto3, python3-googleapi
 Description: daemon that takes log messages from journald and pumps them
  to a given output.  Currently supported outputs are Elasticsearch, Kafka,
- logplex and AWS CloudWatch.  It reads messages from journald and optionally
- checks if they match a config rule and forwards them as JSON messages to
- the desired output.
+ logplex, AWS CloudWatch and Google Cloud Logging. It reads messages from
+ journald and optionally checks if they match a config rule and forwards
+ them as JSON messages to the desired output.

--- a/journalpump.spec
+++ b/journalpump.spec
@@ -5,18 +5,18 @@ Url:            http://github.com/aiven/journalpump
 Summary:        Pump messages from systemd journal to Elasticsearch, Kafka, Logplex or AWS CloudWatch
 License:        ASL 2.0
 Source0:        journalpump-rpm-src.tar.gz
-Requires:       python3-kafka, systemd-python3, python3-requests, python3-boto3
-BuildRequires:  python3-kafka, systemd-python3, python3-requests, python3-boto3
+Requires:       python3-kafka, systemd-python3, python3-requests, python3-boto3, python3-google-api-client
+BuildRequires:  python3-kafka, systemd-python3, python3-requests, python3-boto3, python3-google-api-client
 BuildRequires:  python3-devel, python3-pytest, python3-pylint python3-responses
 BuildArch:      noarch
 Obsoletes:      kafkajournalpump
 
 %description
 journalpump is a daemon that takes log messages from journald and pumps them
-to a given output.  Currently supported outputs are Elasticsearch, Kafka,
-logplex and AWS CloudWatch.  It reads messages from journald and optionally
-checks if they match a config rule and forwards them as JSON messages to the desired
-output.
+to a given output. Currently supported outputs are Elasticsearch, Kafka,
+logplex, AWS CloudWatch and Google Cloud Logging.  It reads messages from journald
+and optionally checks if they match a config rule and forwards them as JSON
+messages to the desired output.
 
 
 %prep

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -10,7 +10,8 @@ from functools import reduce
 from systemd.journal import Reader
 from .senders.base import MAX_KAFKA_MESSAGE_SIZE
 from .senders.base import Tagged
-from .senders import AWSCloudWatchSender, RsyslogSender, LogplexSender, FileSender, KafkaSender, ElasticsearchSender
+from .senders import (AWSCloudWatchSender, RsyslogSender, LogplexSender, FileSender,
+                      KafkaSender, ElasticsearchSender, GoogleCloudLoggingSender)
 import copy
 import datetime
 import json
@@ -198,7 +199,8 @@ class JournalReader(Tagged):
             "logplex": LogplexSender,
             "file": FileSender,
             "rsyslog": RsyslogSender,
-            "aws_cloudwatch": AWSCloudWatchSender
+            "aws_cloudwatch": AWSCloudWatchSender,
+            "google_cloud_logging": GoogleCloudLoggingSender,
         }
         for sender_name, sender_config in self.config.get("senders", {}).items():
             try:

--- a/journalpump/senders/__init__.py
+++ b/journalpump/senders/__init__.py
@@ -4,3 +4,4 @@ from .aws_cloudwatch import AWSCloudWatchSender  # noqa: F401
 from .elasticsearch import ElasticsearchSender  # noqa: F401
 from .rsyslog import RsyslogSender  # noqa: F401
 from .logplex import LogplexSender  # noqa: F401
+from .google_cloud_logging import GoogleCloudLoggingSender  # noqa: F401

--- a/journalpump/senders/google_cloud_logging.py
+++ b/journalpump/senders/google_cloud_logging.py
@@ -1,0 +1,97 @@
+from .base import LogSender
+
+from googleapiclient.discovery import build
+from googleapiclient.errors import Error as GoogleApiClientError
+from oauth2client.service_account import ServiceAccountCredentials
+
+import json
+
+
+class GoogleCloudLoggingSender(LogSender):
+    _SEVERITY_MAPPING = {  # mapping from journald priority to cloud logging severity
+        7: "DEBUG",
+        6: "INFO",
+        5: "NOTICE",
+        4: "WARNING",
+        3: "ERROR",
+        2: "CRITICAL",
+        1: "ALERT",
+        0: "EMERGENCY",
+    }
+
+    def __init__(self, *, config, googleapiclient_request_builder=None, **kwargs):
+        super().__init__(
+            config=config,
+            max_send_interval=config.get("max_send_interval", 0.3),
+            **kwargs
+        )
+        credentials = None
+        google_service_account = config.get("google_service_account_credentials")
+        self.project_id = config["google_cloud_logging_project_id"]
+        self.log_id = config["google_cloud_logging_log_id"]
+        self.resource_labels = config.get("google_cloud_logging_resource_labels", None)
+        if google_service_account:
+            credentials = ServiceAccountCredentials.from_json_keyfile_dict(google_service_account)
+            self.project_id = google_service_account["project_id"]
+        else:
+            credentials = ServiceAccountCredentials.get_application_default()
+
+        if googleapiclient_request_builder is not None:
+            self._logs = build(
+                "logging",
+                "v2",
+                credentials=credentials,
+                requestBuilder=googleapiclient_request_builder
+            )
+        else:
+            self._logs = build(
+                "logging",
+                "v2",
+                credentials=credentials
+            )
+        self.mark_connected()
+
+    def send_messages(self, *, messages, cursor):
+        body = {
+            "logName": "projects/%s/logs/%s" % (self.project_id, self.log_id),
+            "resource": {
+                "type": "generic_node",
+            },
+            "entries": []
+        }
+
+        if self.resource_labels is not None:
+            body["resource"]["labels"] = self.resource_labels
+
+        for message in messages:
+            msg_str = message.decode("utf8")
+            msg = json.loads(msg_str)
+            timestamp = msg.pop("timestamp", None)
+            journald_priority = msg.pop("PRIORITY", None)
+            entry = {
+                "jsonPayload": msg,
+            }
+            if timestamp is not None:
+                entry["timestamp"] = timestamp
+            if journald_priority is not None:
+                severity = GoogleCloudLoggingSender._SEVERITY_MAPPING.get(journald_priority, "DEFAULT")
+                entry["severity"] = severity
+            body["entries"].append(entry)
+
+        try:
+            self._logs.entries().write(body=body).execute()  # pylint: disable=no-member
+            self.mark_sent(messages=messages, cursor=cursor)
+            return True
+        except GoogleApiClientError as err:
+            self.mark_disconnected(err)
+            self.log.exception("Client error during send to Google Cloud Logging")
+            self.stats.unexpected_exception(ex=err, where="sender", tags=self.make_tags({"app": "journalpump"}))
+            self._backoff()
+            self.mark_connected()
+        except Exception as ex:  # pylint: disable=broad-except
+            self.mark_disconnected(ex)
+            self.log.exception("Unexpected exception during send to Google Cloud Logging")
+            self.stats.unexpected_exception(ex=ex, where="sender", tags=self.make_tags({"app": "journalpump"}))
+            self._backoff()
+            self.mark_connected()
+        return False

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -2,8 +2,11 @@ from collections import OrderedDict
 from datetime import datetime
 from journalpump.util import default_json_serialization
 from journalpump.senders.base import MsgBuffer, MAX_KAFKA_MESSAGE_SIZE
-from journalpump.senders import ElasticsearchSender, KafkaSender, LogplexSender, RsyslogSender, AWSCloudWatchSender
+from journalpump.senders import (ElasticsearchSender, KafkaSender, LogplexSender, RsyslogSender,
+                                 AWSCloudWatchSender, GoogleCloudLoggingSender)
 from journalpump.journalpump import FieldFilter, JournalObject, JournalObjectHandler, JournalPump
+from googleapiclient.http import RequestMockBuilder as GoogleApiClientRequestMockBuilder
+from httplib2 import Response as HttpLib2Response
 
 import responses
 from time import sleep
@@ -12,6 +15,36 @@ from botocore.stub import Stubber
 import boto3
 
 import json
+
+_PRIVATE_KEY = \
+    "-----BEGIN PRIVATE KEY-----\n" + \
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCpvu/5QUyQpYRT\n" + \
+    "t1vAWbCcWOc1xxbGKIjMVZTY+FCaHPeJWWevgGIJnZKL/ZCfkHusZ2LfPFgdxeBr\n" + \
+    "R7qIGYvDv+Ez2Z2JF4UvhLGtvUtabOHu50P9XtGVB53YUisGqlVJqpAeKXR2t0kb\n" + \
+    "DaPgTjiP3wroe1/RpjkAdgny25X6dwk7eBELo7pB8CqqCuOE1gADOr46DmcnPGcr\n" + \
+    "nkyqpoUn8v0fDi4LwP3bQK6F8Yj8oTa2Vm/vXXZ9pLdBfkzm7evKi8Ujtj1i40Wr\n" + \
+    "XQ3VxlqbF/zdn1c4LpT9qQuwwu8eqcyNbzC7lGvhJ9nmGN+Fpb49kTk4EZ32HygS\n" + \
+    "0G5n1zrrAgMBAAECggEAQQpr2gaGx1/cedVmnyfer7Gy+hysYcZTUHQ0YgSXoc2a\n" + \
+    "nbK3s3wOVJ/fcKt6eGF8ud0tedsd6l6RNJoZ459iOeGycVMfdVGhU0lVaXyAPIg+\n" + \
+    "8/MCTrm/tYpjFWm6mcW3g1ALA7ufqANnzCloUwC11I7Cl7z6RJMcAUy5WCiCaaMF\n" + \
+    "U/QDhhkNQwqowiQGamJNbE13L47lSuo50Nu3Ximh1vRZQz11IHIGJMe9N95vUHTI\n" + \
+    "mqViUtpJ2UyPW737cTPfvG4KH/xO7s9y/kAQuXBjF4c+2Z5vk3lDOmRleUusj0Ru\n" + \
+    "5m5aM56WxBucqjn6vsDPCqSyzNuxi3G8YD0mUiSBQQKBgQDlmlW/99g497FuePI0\n" + \
+    "MFoVeENEZQOnb+q9vhaIyYyWvRiQCsK/eKe8kCBMVGOR0bRiprKs+cAQN94lP45h\n" + \
+    "bptMmcUWgF7N1arcKaUdR9EU6BujaEzzJxMSZAdJrqb77/bNuCDF6LTHTLD9muj4\n" + \
+    "TM6IqkZZgOChbqgEP1fXC2bXwQKBgQC9QuRuWD2Bv3E0h7OA6kz46oLQnOeryFlI\n" + \
+    "9MVKvSkUkxwJL+9UrnWQzXhKgWbTqpR9+/l82WZ8DrDAn8P1h7aYW2rB7QSi93A6\n" + \
+    "rRSSkjKoh+peFoZqrH6B2BpKBt5XO26nmZl2hbFkNvoBW4mlXjqC3uxbGXTeI0qC\n" + \
+    "lu+HvsRdqwKBgEDi+eLTjyaiUWFwCrrXA05X+2KjzYGPLl7LDqE/nFypOfzTHbBw\n" + \
+    "z66JaKdJng4CnqDWjV43AqFSuJP8Pyen03m1Zy5xvtkazjuEBWad+ieXZOAsRLre\n" + \
+    "yxQCctDO69/9M9l1dMWZeyVrtgUltzscsa2LuW/n7ROSKydwI0nhrgHBAoGARvsG\n" + \
+    "dwfrEXU+PMhEHy5Abf5tz1V5YajDK6R5Nd2ZwZimpB9xMB46A3O8EJ1Vdj78b/+H\n" + \
+    "gzZ5xD8yNRv2P2iFp8BpWo/M9F2+npL5Kztfemt3D5B9GxbUX1gwC+Flk+u7RWpK\n" + \
+    "7vOXIxGnU8kD55xeb2Sx2jzC4ujzceSvswZt2P8CgYEApjeIYIzvefUq6A1PqRS3\n" + \
+    "6uFBU3jl4MdRVSNK7cZ2XTMVFBotBx6slxhsu0mCmIJGqLng+PBQduv720Rfz29I\n" + \
+    "V3HRVsywgOVHazpYtKppJXB7jy60/U/ARf4ZbysgxhFKUbsjUWAmpdz2Jy1H8XHu\n" + \
+    "Br8FLEY2+iOAvkgZLxZMLbM=\n" + \
+    "-----END PRIVATE KEY-----\n"
 
 
 def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
@@ -198,6 +231,48 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
             assert s._next_sequence_token == "token"
             # pylint: enable=protected-access
             assert isinstance(s, AWSCloudWatchSender)
+
+    # Google Cloud Logging sender
+    config = {
+        "readers": {
+            "foo": {
+                "senders": {
+                    "bar": {
+                        "output_type": "google_cloud_logging",
+                        "google_cloud_logging_project_id": "project-id",
+                        "google_cloud_logging_log_id": "log-id",
+                        "google_service_account_credentials": {
+                            "type": "service_account",
+                            "project_id": "project-id",
+                            "private_key_id": "abcdefg",
+                            "private_key": _PRIVATE_KEY,
+                            "client_email": "test@project-id.iam.gserviceaccount.com",
+                            "client_id": "123456789",
+                            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                            "token_uri": "https://oauth2.googleapis.com/token",
+                            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                            "client_x509_cert_url":
+                                "https://www.googleapis.com/robot/v1/metadata/x509/test%40project-id.iam.gserviceaccount.com"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    with open(journalpump_path, "w") as fp:
+        fp.write(json.dumps(config))
+    a = JournalPump(journalpump_path)
+
+    assert len(a.readers) == 1
+    for rn, r in a.readers.items():
+        assert rn == "foo"
+        r.create_journald_reader_if_missing()
+        assert len(r.senders) == 1
+        r.running = False
+        for sn, s in r.senders.items():
+            assert sn == "bar"
+            s.running = False
+            assert isinstance(s, GoogleCloudLoggingSender)
 
 
 def test_journal_reader_tagging(tmpdir):
@@ -483,3 +558,119 @@ def test_awscloudwatch_sender():
         sender.send_messages(messages=[b'{"REALTIME_TIMESTAMP": 1590581737.308352}'], cursor=None)
         assert sender._connected  # pylint: disable=protected-access
         assert sender._sent_count == 3  # pylint: disable=protected-access
+
+
+def test_google_cloud_logging_sender():
+    config = {
+        "google_cloud_logging_project_id": "project-id",
+        "google_cloud_logging_log_id": "log-id",
+        "google_cloud_logging_resource_labels": {
+            "location": "us-east-1",
+            "node_id": "my-test-node",
+        },
+        "google_service_account_credentials": {
+            "type": "service_account",
+            "project_id": "project-id",
+            "private_key_id": "abcdefg",
+            "private_key": _PRIVATE_KEY,
+            "client_email": "test@project-id.iam.gserviceaccount.com",
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_x509_cert_url":
+                "https://www.googleapis.com/robot/v1/metadata/x509/test%40project-id.iam.gserviceaccount.com"
+        }
+    }
+
+    expected_body = {
+        "logName": "projects/project-id/logs/log-id",
+        "resource":
+            {
+                "type": "generic_node",
+                "labels": {
+                    "location": "us-east-1",
+                    "node_id": "my-test-node"
+                },
+            },
+        "entries": [
+            {
+                "jsonPayload": {
+                    "message": "Hello"
+                }
+            }]
+    }
+    requestBuilder = GoogleApiClientRequestMockBuilder(
+        {
+            'logging.entries.write': (None, "{}", expected_body),
+        },
+        check_unexpected=True,
+    )
+
+    sender = GoogleCloudLoggingSender(
+        name="googlecloudlogging",
+        reader=mock.Mock(),
+        stats=mock.Mock(),
+        field_filter=None,
+        config=config,
+        googleapiclient_request_builder=requestBuilder
+    )
+    sender.send_messages(messages=[b'{"message": "Hello"}'], cursor=None)
+    assert sender._sent_count == 1  # pylint: disable=protected-access
+
+    requestBuilder = GoogleApiClientRequestMockBuilder(
+        {
+            'logging.entries.write': (HttpLib2Response({"status": "400"}), b"", expected_body),
+        },
+        check_unexpected=True,
+    )
+
+    sender = GoogleCloudLoggingSender(
+        name="googlecloudlogging",
+        reader=mock.Mock(),
+        stats=mock.Mock(),
+        field_filter=None,
+        config=config,
+        googleapiclient_request_builder=requestBuilder
+    )
+    sender.send_messages(messages=[b'{"message": "Hello"}'], cursor=None)
+    assert sender._sent_count == 0  # pylint: disable=protected-access
+
+    expected_body = {
+        "logName": "projects/project-id/logs/log-id",
+        "resource":
+            {
+                "type": "generic_node",
+                "labels": {
+                    "location": "us-east-1",
+                    "node_id": "my-test-node"
+                },
+            },
+        "entries": [
+            {
+                "timestamp": "2020-06-25T06:24:13.787255",
+                "severity": "EMERGENCY",
+                "jsonPayload": {
+                    "message": "Hello"
+                }
+            }]
+    }
+    requestBuilder = GoogleApiClientRequestMockBuilder(
+        {
+            'logging.entries.write': (None, "{}", expected_body),
+        },
+        check_unexpected=True,
+    )
+
+    sender = GoogleCloudLoggingSender(
+        name="googlecloudlogging",
+        reader=mock.Mock(),
+        stats=mock.Mock(),
+        field_filter=None,
+        config=config,
+        googleapiclient_request_builder=requestBuilder
+    )
+    sender.send_messages(messages=[
+        b'{"message": "Hello", "PRIORITY": 0, "timestamp": "2020-06-25T06:24:13.787255"}'
+    ], cursor=None)
+    assert sender._sent_count == 1  # pylint: disable=protected-access


### PR DESCRIPTION
Added new logs sender for Google Cloud Logging. Logs are labeled as `generic_node` type monitored resources and it is possible to pass in labels allowed by this type. For more info see https://cloud.google.com/monitoring/api/resources#tag_generic_node.

Requires Google Service Account type credentials. If credentials are not set in journalpump config it will attempt to find credentials from system.