### PR TITLE
google_cloud_logging: few improvements

### DIFF
--- a/journalpump/senders/google_cloud_logging.py
+++ b/journalpump/senders/google_cloud_logging.py
@@ -5,6 +5,9 @@ from googleapiclient.errors import Error as GoogleApiClientError
 from oauth2client.service_account import ServiceAccountCredentials
 
 import json
+import logging
+
+logging.getLogger("googleapiclient.discovery").setLevel(logging.WARNING)
 
 
 class GoogleCloudLoggingSender(LogSender):

--- a/journalpump/senders/google_cloud_logging.py
+++ b/journalpump/senders/google_cloud_logging.py
@@ -75,7 +75,7 @@ class GoogleCloudLoggingSender(LogSender):
                 "jsonPayload": msg,
             }
             if timestamp is not None:
-                entry["timestamp"] = timestamp
+                entry["timestamp"] = timestamp[:26] + "Z"  # assume timestamp to be UTC
             if journald_priority is not None:
                 severity = GoogleCloudLoggingSender._SEVERITY_MAPPING.get(journald_priority, "DEFAULT")
                 entry["severity"] = severity

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -648,7 +648,7 @@ def test_google_cloud_logging_sender():
             },
         "entries": [
             {
-                "timestamp": "2020-06-25T06:24:13.787255",
+                "timestamp": "2020-06-25T06:24:13.787255Z",
                 "severity": "EMERGENCY",
                 "jsonPayload": {
                     "message": "Hello"


### PR DESCRIPTION
The `googleapiclient` was logging at `INFO` loglevel for all requests made a against the logging API. I reduced the verbosity of logging to `WARNING`.

Also, fixed the ISO8601 formatted timestamp to include timezone if it is missing. Assuming all timestamps to be UTC.