### PR TITLE
Automatic topic creation for kafka sender

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -345,6 +345,19 @@ Which Kafka server API version to use.
 Which Kafka topic do you want the journalpump to write to.
 Required when using output_type ``kafka``.
 
+``kafka_topic_config`` (default ``null``)
+
+If this key is present, its value must be another mapping with the default
+configuration used to create the topic, if it does not exist yet.
+
+The mapping must have these values::
+
+  {
+      "num_partitions": 3,
+      "replication_factor": 3
+  }
+
+
 ``kafka_address`` (default ``null``)
 
 The address of the kafka server which to write to.

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Other::
 
 This will produce an egg file into a dist directory within the same folder.
 
-For a source install the dependency [python-systemd](https://github.com/systemd/python-systemd) has
+For a source install the dependency `python-systemd <https://github.com/systemd/python-systemd>`_ has
 to be installed through your distribution's package manager (The PyPI `systemd` package is not the
 same!).
 
@@ -102,6 +102,7 @@ Top level configuration
 Example::
 
   {
+      "log_level": "INFO",
       "field_filters": {
          ...
       },
@@ -137,7 +138,7 @@ Metrics sending follows the `Telegraf spec`_.
 
 ``log_level`` (default ``"INFO"``)
 
-Determines log level of journalpump.
+Determines log level of journalpump. `Available log levels <https://docs.python.org/3/library/logging.html#logging-levels>`_.
 
 Field filter configuration
 ==========================

--- a/journalpump/senders/kafka.py
+++ b/journalpump/senders/kafka.py
@@ -65,7 +65,7 @@ class KafkaSender(LogSender):
     def _init_kafka(self) -> None:
         self.log.info("Initializing Kafka client, address: %r", self.config["kafka_address"])
         self.mark_disconnected()
-        while self.running:
+        while self.running and not self._connected:
             producer_config = self._generate_producer_config()
             try:
                 if self.kafka_producer:
@@ -75,7 +75,6 @@ class KafkaSender(LogSender):
 
                 self.log.info("Initialized Kafka Client, address: %r", self.config["kafka_address"])
                 self.mark_connected()
-                break
             except KAFKA_CONN_ERRORS as ex:
                 self.mark_disconnected(ex)
                 self.log.warning("Retriable error during Kafka initialization: %s: %s", ex.__class__.__name__, ex)

--- a/journalpump/senders/kafka.py
+++ b/journalpump/senders/kafka.py
@@ -3,7 +3,6 @@ from kafka import errors, KafkaProducer
 
 import logging
 import socket
-import time
 
 try:
     import snappy
@@ -63,7 +62,7 @@ class KafkaSender(LogSender):
 
         return producer_config
 
-    def _init_kafka(self):
+    def _init_kafka(self) -> None:
         self.log.info("Initializing Kafka client, address: %r", self.config["kafka_address"])
         self.mark_disconnected()
         while self.running:
@@ -82,7 +81,6 @@ class KafkaSender(LogSender):
                 self.log.warning("Retriable error during Kafka initialization: %s: %s", ex.__class__.__name__, ex)
                 self._backoff()
             self.kafka_producer = None
-            time.sleep(5.0)
 
     def send_messages(self, *, messages, cursor):
         if not self.kafka_producer:

--- a/journalpump/senders/kafka.py
+++ b/journalpump/senders/kafka.py
@@ -1,5 +1,6 @@
 from .base import LogSender
-from kafka import errors, KafkaProducer
+from kafka import errors, KafkaAdminClient, KafkaProducer
+from kafka.admin import NewTopic
 
 import logging
 import socket
@@ -31,22 +32,27 @@ class KafkaSender(LogSender):
             self.kafka_msg_key = self.kafka_msg_key.encode("utf8")
         self.topic = self.config.get("kafka_topic")
 
-    def _generate_producer_config(self) -> dict:
-        producer_config = {
+    def _generate_client_config(self) -> dict:
+        config = {
             "api_version": self.config.get("kafka_api_version"),
             "bootstrap_servers": self.config.get("kafka_address"),
-            "linger_ms": 500,  # wait up 500 ms to see if we can send msgs in a group
             "reconnect_backoff_ms": 1000,  # up from the default 50ms to reduce connection attempts
             "reconnect_backoff_max_ms": 10000,  # up the upper bound for backoff to 10 seconds
         }
 
         if self.config.get("ssl"):
-            producer_config["security_protocol"] = "SSL"
-            producer_config["ssl_cafile"] = self.config.get("ca")
-            producer_config["ssl_certfile"] = self.config.get("certfile")
-            producer_config["ssl_keyfile"] = self.config.get("keyfile")
+            config["security_protocol"] = "SSL"
+            config["ssl_cafile"] = self.config.get("ca")
+            config["ssl_certfile"] = self.config.get("certfile")
+            config["ssl_keyfile"] = self.config.get("keyfile")
         else:
-            producer_config["security_protocol"] = "PLAINTEXT"
+            config["security_protocol"] = "PLAINTEXT"
+
+        return config
+
+    def _generate_producer_config(self) -> dict:
+        producer_config = self._generate_client_config()
+        producer_config["linger_ms"] = 500  # wait up 500 ms to see if we can send msgs in a group
 
         # make sure the python client supports it as well
         if zstd and "zstd" in KafkaProducer._COMPRESSORS:  # pylint: disable=protected-access
@@ -84,6 +90,21 @@ class KafkaSender(LogSender):
                 self.log.info("Initialized Kafka Client, address: %r", self.config["kafka_address"])
                 self.kafka_producer = kafka_producer
                 self.mark_connected()
+
+        # Assume that when the topic configuration is provided we should
+        # manually create it. This is useful for kafka clusters configured with
+        # `auto.create.topics.enable = false`
+        topic_config = self.config.get("kafka_topic_config", dict())
+        num_partitions = topic_config.get("num_partitions")
+        replication_factor = topic_config.get("replication_factor")
+        if num_partitions is not None and replication_factor is not None:
+            kafka_admin = KafkaAdminClient(**self._generate_client_config())
+            try:
+                kafka_admin.create_topics([NewTopic(self.topic, num_partitions, replication_factor)])
+            except errors.TopicAlreadyExistsError:
+                self.log.info("Kafka topic %r already exists", self.topic)
+            else:
+                self.log.info("Create Kafka topic, address: %r", self.topic)
 
     def send_messages(self, *, messages, cursor):
         if not self.kafka_producer:


### PR DESCRIPTION
Useful for clusters configured with `auto.create.topics.enable = false`.

I manually tested this with:

Journalpump `config.json`:
```json
{
    "log_level": "DEBUG",
    "readers": {
        "host1": {
            "senders": {
                "kafka1": {
                    "output_type": "kafka",
                    "kafka_address": "127.0.0.1:9092",
                    "kafka_topic": "journals",
                    "kafka_topic_config": {
                        "num_partitions": 1,
                        "replication_factor": 1
                    }
                }
            }
        }
    }
}
```

Script `generate_event.py` to generate events:
```python
import logging
from systemd.journal import JournalHandler

log = logging.getLogger('demo')
log.addHandler(JournalHandler())
log.setLevel(logging.INFO)
log.info("sent to journal")
```

```sh
ip=$(ip -j address show wlp0s20f3 | jq '.[0].addr_info | .[] | select(.family=="inet").local' -r)
podman run --rm --env ZOOKEEPER_CLIENT_PORT=2181 -p 2181 confluentinc/cp-zookeeper
podman run --rm --env KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT --env "KAFKA_ZOOKEEPER_CONNECT=$ip:2181" --env KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:29092,PLAINTEXT_HOST://127.0.0.1:9092 --env KAFKA_AUTO_CREATE_TOPICS_ENABLE=false -p 9092 -p 29092 confluentinc/cp-kafka
journalpump config.json
python generate_event.py
```