### PR TITLE
awscloudwatchsender: fix crash due to wrong credentials

### DIFF
--- a/journalpump/senders/base.py
+++ b/journalpump/senders/base.py
@@ -11,6 +11,10 @@ MAX_ERROR_MESSAGES = 8
 MAX_ERROR_MESSAGE_LEN = 128
 
 
+class SenderInitializationError(Exception):
+    """Error during sender initialization"""
+
+
 # Map running/_connected to health
 def _convert_to_health(*, running, connected):
     if running:

--- a/journalpump/senders/file.py
+++ b/journalpump/senders/file.py
@@ -5,7 +5,7 @@ class FileSender(LogSender):
     def __init__(self, *, config, **kwargs):
         super().__init__(config=config, max_send_interval=config.get("max_send_interval", 0.3), **kwargs)
         self.mark_disconnected()
-        self.output = open(config["file_output"], "ab")
+        self.output = open(config["file_output"], "ab")  # pylint: disable=consider-using-with
         self.mark_connected()
 
     def send_messages(self, *, messages, cursor):

--- a/systest/test_rsyslog.py
+++ b/systest/test_rsyslog.py
@@ -55,6 +55,7 @@ class _TestRsyslogd:
 
     def start(self):
         # Start rsyslogd in the foreground
+        # pylint: disable=consider-using-with
         self.process = Popen([RSYSLOGD, "-f", self.conffile, "-i", "NONE", "-n", "-C"])
         self._wait_until_running()
 


### PR DESCRIPTION
Journalpump would crash if `AWSCloudwatchSender` got
`AccessDeniedException` during sender init. This can
happen if there are wrong credentials in config.

All `ClientError` class AWS errors are now caught during init
and retried a few times. This will catch `AccessDeniedException`
and transient `ServiceUnavailable` errors.

`AccessDeniedException` errors are reported to `JournalReader`. 
`JournalReader` ignores senders that failed to initialize during operation.


