### PR TITLE
Also add reference to Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Building
 To build an installation package for your distribution, go to the root
 directory of a journalpump Git checkout and then run:
 
-Debian::
+Debian/Ubuntu::
 
   make deb
 
@@ -48,7 +48,7 @@ Installation
 
 To install it run as root:
 
-Debian::
+Debian/Ubuntu::
 
   dpkg -i ../journalpump*.deb
 


### PR DESCRIPTION
Since Ubuntu is one of the most popular distro, there are people with different knowledge that uses it.  Some people won't realize that the instructions for Debian are also valid for Ubuntu