### PR TITLE
websocket: Support for batches of messages and compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,14 @@ build-dep-fed:
 	sudo dnf -y --best --allowerasing install \
 		python3-flake8 python3-kafka python3-pytest python3-pylint \
 		python3-requests python3-responses systemd-python3 python3-boto3 \
-		python3-websockets python3-aiohttp-socks \
+		python3-websockets python3-aiohttp-socks python3-snappy \
 		python3-google-api-client
 
 build-dep-deb:
 	sudo apt-get install \
 		build-essential devscripts dh-systemd \
 		python-all python-setuptools python3-systemd python3-kafka \
-		python3-websockets python3-aiohttp-socks \
+		python3-websockets python3-aiohttp-socks python3-snappy \
 		python3-boto python3-googleapi
 
 

--- a/README.rst
+++ b/README.rst
@@ -515,6 +515,26 @@ authentication.
 
 Defined socks5 proxy to use for Websocket connections.
 
+``max_batch_size`` (default ``1048576``)
+
+Adjust message batch size, set to 0 to disable batching.  When batching is
+enabled, multiple journal messages are sent in a single websocket message,
+separated by a single NUL byte.
+
+``compression`` (default ``"snappy"``)
+
+Compress messages on application level using the specified algorithm.
+Decompression is done by an application behind the websocket server,
+allowing end-to-end compression.  When batching is enabled, compression is
+done on complete batches.  Supported values: ``"snappy"``, ``"none"``.
+
+``websocket_compression`` (default ``"none"``)
+
+Enable compression of websocket messages using the ``permessage-deflate``
+extension.  The messages will be decompressed by the websocket server.  When
+batching is enabled, compression is done on complete batches.  Supported
+values: ``"deflate"``, ``"none"``.
+
 
 
 License

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Depends: ${misc:Depends}, ${python3:Depends}, adduser,
  python3-elasticsearch, python3-kafka,
  python3-requests, python3-systemd,
  python3-boto3, python3-googleapi,
- python3-websockets, python3-aiohttp-socks
+ python3-websockets, python3-aiohttp-socks, python3-snappy
 Description: daemon that takes log messages from journald and pumps them
  to a given output.  Currently supported outputs are Elasticsearch, Kafka,
  Websocket, logplex, AWS CloudWatch and Google Cloud Logging. It reads

--- a/journalpump.spec
+++ b/journalpump.spec
@@ -7,10 +7,10 @@ License:        ASL 2.0
 Source0:        journalpump-rpm-src.tar.gz
 Requires:       python3-kafka, systemd-python3, python3-requests, python3-boto3, python3-google-api-client
 Requires:       python3-oauth2client, python3-geoip2, python3-typing-extensions
-Requires:	python3-websockets, python3-aiohttp-socks
+Requires:	python3-websockets, python3-aiohttp-socks, python3-snappy
 BuildRequires:  python3-kafka, systemd-python3, python3-requests, python3-boto3, python3-google-api-client
 BuildRequires:  python3-devel, python3-pytest, python3-pylint python3-responses
-BuildRequires:	python3-websockets, python3-aiohttp-socks
+BuildRequires:	python3-websockets, python3-aiohttp-socks, python3-snappy
 BuildArch:      noarch
 Obsoletes:      kafkajournalpump
 

--- a/journalpump/types.py
+++ b/journalpump/types.py
@@ -1,4 +1,5 @@
 """JournalPump internal types"""
+import enum
 import sys
 
 if sys.version_info >= (3, 8):
@@ -14,3 +15,8 @@ class GeoIPProtocol(Protocol):
     GeoIP is not a required dependency, but to typecheck we want to ensure
     that we don't escalate the methods without necessity.
     """
+
+
+class StrEnum(str, enum.Enum):
+    def __str__(self):
+        return str(self.value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ kafka-python
 requests
 websockets
 aiohttp-socks
+python-snappy
 boto3
 google-api-python-client
 oauth2client


### PR DESCRIPTION
Support sending journal messages in batches, with complete batches being
compressed using snappy on application level, or alternatively using deflate
with the websocket permessage-deflate extension.  Application-level
compression of a batch inside the message is end-to-end, while
permessage-deflate compression only works up to the websocket server.