### PR TITLE
websocket sender: Use socks5_proxy config parameter name

### DIFF
--- a/journalpump/__init__.py
+++ b/journalpump/__init__.py
@@ -3,4 +3,4 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 """journalpump"""
-__version__ = "2.3.6"
+__version__ = "2.3.7"

--- a/journalpump/senders/websocket.py
+++ b/journalpump/senders/websocket.py
@@ -283,7 +283,7 @@ class WebsocketSender(LogSender):
             try:
                 runner = WebsocketRunner(
                     websocket_uri=self.config["websocket_uri"],
-                    socks5_proxy_url=self.config.get("socks5_proxy_url"),
+                    socks5_proxy_url=self.config.get("socks5_proxy"),
                     ssl_enabled=self.config.get("ssl"),
                     ssl_ca=self.config.get("ca"),
                     ssl_key=self.config.get("keyfile"),


### PR DESCRIPTION
This is consistent with the parameter name used by the kafka sender.

Bump version number to 2.3.7.