### PR TITLE
websocket sender: Use a longer connection timeout and slower retries, version 2.4.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ journalpump 2.4.0 (2022-01-05)
 * Updated polling algorithm to perform better when continiously receiving messages
 * Handle invalidation event to prevent keeping deleted files
 
+journalpump 2.3.6 (2021-10-20)
+==============================
+* Added Websocket sender
+
 journalpump 2.3.0 (2020-06-15)
 ==============================
 * Added Google Cloud Logging logs sender

--- a/journalpump/__init__.py
+++ b/journalpump/__init__.py
@@ -3,4 +3,4 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 """journalpump"""
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/journalpump/senders/websocket.py
+++ b/journalpump/senders/websocket.py
@@ -61,7 +61,7 @@ class WebsocketRunner(Thread):
         self.batch_message_overhead = 1
         self.compression = compression
         self.websocket_compression = websocket_compression
-        self.backoff = ExponentialBackoff(base=10, factor=1.8, maximum=60, jitter=True)
+        self.backoff = ExponentialBackoff(base=20, factor=1.8, maximum=90, jitter=True)
         # prevent websockets from logging message contents when we're otherwise in DEBUG mode
         logging.getLogger("websockets").setLevel(logging.INFO)
 
@@ -172,7 +172,7 @@ class WebsocketRunner(Thread):
             max_size=MAX_KAFKA_MESSAGE_SIZE * 2,
         )
 
-    async def websocket_connect(self, *, timeout=5):
+    async def websocket_connect(self, *, timeout=30):
         connect_task = asyncio.create_task(self.websocket_connect_coro())
         wait_for_stop_task = asyncio.create_task(self.wait_for_stop_event())
 


### PR DESCRIPTION
Reduce effects of reconnection storms by giving more time for the handshake to complete and retry slightly less often.
