### PR TITLE
Handle TimeoutError as retriable

### DIFF
--- a/journalpump/__init__.py
+++ b/journalpump/__init__.py
@@ -3,4 +3,4 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 """journalpump"""
-__version__ = "2.4.1"
+__version__ = "2.4.2"

--- a/journalpump/senders/kafka.py
+++ b/journalpump/senders/kafka.py
@@ -18,6 +18,7 @@ except ImportError:
 KAFKA_CONN_ERRORS = tuple(errors.RETRY_ERROR_TYPES) + (
     errors.UnknownError,
     socket.timeout,
+    TimeoutError,
 )
 
 logging.getLogger("kafka").setLevel(logging.CRITICAL)  # remove client-internal tracebacks from logging output

--- a/journalpump/senders/rsyslog.py
+++ b/journalpump/senders/rsyslog.py
@@ -5,7 +5,7 @@ import json
 import socket
 import time
 
-RSYSLOG_CONN_ERRORS = (socket.timeout, ConnectionRefusedError)
+RSYSLOG_CONN_ERRORS = (socket.timeout, ConnectionRefusedError, TimeoutError)
 
 
 class RsyslogSender(LogSender):
@@ -56,6 +56,7 @@ class RsyslogSender(LogSender):
     def send_messages(self, *, messages, cursor):
         if not self.rsyslog_client:
             self._init_rsyslog_client()
+
         try:
             for msg in messages:
                 message = json.loads(msg.decode("utf8"))


### PR DESCRIPTION
TimeoutError could be raised instead of socket.timeout
due to low values of tcp keepalive
Starting from py3.10 socket.timeout is alias to TimeoutError