### PR TITLE
base: add heartbeat messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -580,6 +580,31 @@ Client key path, required if remote syslog requires SSL authentication.
 
 Format message according to rfc5424 or rfc3164
 
+``max_heartbeat_interval`` (default ``null``)
+
+The amount of seconds to wait between sending heartbeat messages. Heartbeats will only be sent if
+this field is not null.
+
+``heartbeat_hostname`` (default ``socket.gethostname()``)
+
+The hostname to use for heartbeat messages.
+
+``heartbeat_facility`` (default ``5``)
+
+The facility to use for heartbeat messages.
+
+``heartbeat_severity`` (default ``7``)
+
+The facility to use for heartbeat messages.
+
+``heartbeat_program`` (default ``journalpump``)
+
+The program to use for heartbeat messages.
+
+``heartbeat_message`` (default ``HEARTBEAT``)
+
+The program to use for heartbeat messages.
+
 Websocket Sender Configuration
 ------------------------------
 ``websocket_uri`` (default ``null``)

--- a/systest/test_rsyslog.py
+++ b/systest/test_rsyslog.py
@@ -108,13 +108,23 @@ def _run_pump_test(*, config_path, logfile):
     found = 0
     with open(logfile, "r") as fp:
         lines = fp.readlines()
+
     for txt in ["Info", "Warning", "Error", "Critical"]:
         m = re.compile(r".*{} message for {}.*".format(txt, identifier))
         for line in lines:
             if m.match(line):
                 found += 1
                 break
+
     assert found == 4, "Expected messages not found in syslog"
+
+    # Check heartbeats
+    heartbeats = 0
+    for line in lines:
+        if "TEST HEARTBEAT" in line:
+            heartbeats += 1
+
+    assert heartbeats == 5, "Expected heartbeats not found in syslog"
 
 
 def test_rsyslogd_tcp_sender(tmpdir):
@@ -133,6 +143,8 @@ def test_rsyslogd_tcp_sender(tmpdir):
                             "rsyslog_port": 5140,
                             "format": "custom",
                             "logline": "<%pri%>%timestamp% %HOSTNAME% %app-name%[%procid%]: %msg% {%%} %not-valid-tag%",
+                            "max_heartbeat_interval": 1,
+                            "heartbeat_message": "TEST HEARTBEAT",
                         },
                     },
                 },


### PR DESCRIPTION
this pr is a suggestion of adding heartbeat messages to journalpump. related note from the datadog documentation: 


```
(Optional) Datadog cuts inactive connections after a period of inactivity. Some Rsyslog versions are not able to reconnect properly when necessary. To mitigate this issue, use time markers so the connection never stops. To achieve this, add the following 2 lines in your Rsyslog configuration:

$ModLoad immark
$MarkMessagePeriod 20
And don’t forget to restart:
```

It would be nice to have the same for journalpump