### PR TITLE
elasticsearch: fix trailing slash in session_url

### DIFF
--- a/journalpump/senders/elasticsearch.py
+++ b/journalpump/senders/elasticsearch.py
@@ -10,7 +10,8 @@ import time
 class ElasticsearchSender(LogSender):
     def __init__(self, *, config, **kwargs):
         super().__init__(config=config, max_send_interval=config.get("max_send_interval", 10.0), **kwargs)
-        self.session_url = self.config.get("elasticsearch_url")
+        # ES and OS are sensitive to multiple slashes in the path
+        self.session_url = self.config["elasticsearch_url"].rstrip("/")
         self.last_index_check_time = 0
         self.request_timeout = self.config.get("elasticsearch_timeout", 10.0)
         self.index_days_max = self.config.get("elasticsearch_index_days_max", 3)


### PR DESCRIPTION
ES/OS are very sensitive to having trailing slashes in the configured
URI, resulting in opaque failures to perform certain operations:

```
journalpump[6607]: LogSender:foo  os-mble-test-endpoint INFO      Initialized ES connection
journalpump[6607]: LogSender:foo  os-mble-test-endpoint INFO      Creating index: 'logs-2022-04-07'
journalpump[6607]: LogSender:foo  os-mble-test-endpoint WARNING   Could not create index mappings for: 'logs-2022-04-07', '{"error":"Incorrect HTTP method for uri [//logs-2022-04-07?include_type_name=true] and method [PUT], allowed: [POST]","status":405}' 405
```

In order to mitigate this, we strip trailing slashes from the
`session_url`.

This fixes the problem:

```
journalpump[7877]: journalpump           MainThread      INFO      new config [snip]
journalpump[7877]: LogSender:foo  os-mble-test-endpoint INFO      Initialized ES connection
journalpump[7877]: LogSender:foo  os-mble-test-endpoint INFO      Sent 7 log events to ES successfully: True, took: 0.04s
journalpump[7877]: LogSender:foo  os-mble-test-endpoint INFO      Sent 6 log events to ES successfully: True, took: 0.01s
```