### PR TITLE
rsyslog: remove heartbeats, ignore exceptions on close

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -580,31 +580,6 @@ Client key path, required if remote syslog requires SSL authentication.
 
 Format message according to rfc5424 or rfc3164
 
-``max_heartbeat_interval`` (default ``null``)
-
-The amount of seconds to wait between sending heartbeat messages. Heartbeats will only be sent if
-this field is not null.
-
-``heartbeat_hostname`` (default ``socket.gethostname()``)
-
-The hostname to use for heartbeat messages.
-
-``heartbeat_facility`` (default ``5``)
-
-The facility to use for heartbeat messages.
-
-``heartbeat_severity`` (default ``7``)
-
-The facility to use for heartbeat messages.
-
-``heartbeat_program`` (default ``journalpump``)
-
-The program to use for heartbeat messages.
-
-``heartbeat_message`` (default ``HEARTBEAT``)
-
-The program to use for heartbeat messages.
-
 Websocket Sender Configuration
 ------------------------------
 ``websocket_uri`` (default ``null``)

--- a/journalpump/rsyslog.py
+++ b/journalpump/rsyslog.py
@@ -130,6 +130,8 @@ class SyslogTcpClient:
             return
         try:
             self.socket.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
         finally:
             self.socket = None
 
@@ -152,7 +154,7 @@ class SyslogTcpClient:
 
     def _should_retry(self, *, ex):
         if isinstance(ex, OSError):
-            return ex.errno in (errno.EPIPE, errno.ECONNRESET, errno.ETIMEDOUT)
+            return ex.errno in (errno.EPIPE, errno.ECONNRESET, errno.ETIMEDOUT, errno.ECONNABORTED)
         return False
 
     def log(self, *, facility, severity, timestamp, hostname, program, pid=None, msgid=None, msg=None, sd=None):

--- a/journalpump/senders/rsyslog.py
+++ b/journalpump/senders/rsyslog.py
@@ -1,7 +1,6 @@
 from .base import LogSender
 from journalpump.rsyslog import SyslogTcpClient
 
-import datetime
 import json
 import socket
 import time
@@ -11,12 +10,7 @@ RSYSLOG_CONN_ERRORS = (socket.timeout, ConnectionRefusedError, TimeoutError)
 
 class RsyslogSender(LogSender):
     def __init__(self, *, config, **kwargs):
-        super().__init__(
-            config=config,
-            max_heartbeat_interval=config.get("max_heartbeat_interval"),
-            max_send_interval=config.get("max_send_interval", 0.3),
-            **kwargs
-        )
+        super().__init__(config=config, max_send_interval=config.get("max_send_interval", 0.3), **kwargs)
         self.rsyslog_client = None
         self.sd = None
         self.default_facility = 1
@@ -58,27 +52,6 @@ class RsyslogSender(LogSender):
                 self._backoff()
             self.rsyslog_client = None
             time.sleep(5.0)
-
-    def send_heartbeat(self):
-        if not self.rsyslog_client:
-            self._init_rsyslog_client()
-
-        try:
-            self.rsyslog_client.log(
-                facility=self.config.get("heartbeat_facility", 5),
-                severity=self.config.get("heartbeat_severity", 7),
-                timestamp=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                hostname=self.config.get("heartbeat_hostname", socket.gethostname()),
-                program=self.config.get("heartbeat_program", "journalpump"),
-                msg=self.config.get("heartbeat_message", "HEARTBEAT"),
-            )
-        except RSYSLOG_CONN_ERRORS as ex:
-            self.mark_disconnected(ex)
-            raise ex
-        except Exception as ex:  # pylint: disable=broad-except
-            self.mark_disconnected(ex)
-            self.stats.unexpected_exception(ex=ex, where="sender", tags=self.make_tags({"app": "journalpump"}))
-            raise ex
 
     def send_messages(self, *, messages, cursor):
         if not self.rsyslog_client:

--- a/systest/test_rsyslog.py
+++ b/systest/test_rsyslog.py
@@ -118,14 +118,6 @@ def _run_pump_test(*, config_path, logfile):
 
     assert found == 4, "Expected messages not found in syslog"
 
-    # Check heartbeats
-    heartbeats = 0
-    for line in lines:
-        if "TEST HEARTBEAT" in line:
-            heartbeats += 1
-
-    assert heartbeats == 5, "Expected heartbeats not found in syslog"
-
 
 def test_rsyslogd_tcp_sender(tmpdir):
     workdir = tmpdir.dirname
@@ -143,8 +135,6 @@ def test_rsyslogd_tcp_sender(tmpdir):
                             "rsyslog_port": 5140,
                             "format": "custom",
                             "logline": "<%pri%>%timestamp% %HOSTNAME% %app-name%[%procid%]: %msg% {%%} %not-valid-tag%",
-                            "max_heartbeat_interval": 1,
-                            "heartbeat_message": "TEST HEARTBEAT",
                         },
                     },
                 },


### PR DESCRIPTION
This PR removes heartbeats again since the EPIPE error handling in the
rsyslog sender was not handling errors when closing the connection.
It adds ECONNABORTED to the exceptions that should be expected and
retried once the conncetion has gone cold.