### PR TITLE
Prevent journalpump hang on exceptions

### DIFF
--- a/journalpump/senders/base.py
+++ b/journalpump/senders/base.py
@@ -86,7 +86,9 @@ class LogSender(Thread, Tagged):
         tags=None,
         msg_buffer_max_length=50000
     ):
-        Thread.__init__(self)
+        # Set as daemon, so that an exception in the main thread will not cause the
+        # program to hang indefinitely. It's preferable to exit (and get restarted by systemd).
+        Thread.__init__(self, daemon=True)
         Tagged.__init__(self, tags, sender=name)
         self.log = logging.getLogger("LogSender:{}".format(reader.name))
         self.name = name

--- a/journalpump/statsd.py
+++ b/journalpump/statsd.py
@@ -6,12 +6,14 @@ Supports telegraf's statsd protocol extension for 'key=value' tags:
   https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd
 
 """
+import logging
 import socket
 
 
 class StatsClient:
     def __init__(self, host="127.0.0.1", port=8125, tags=None):
         self._dest_addr = (host, port)
+        self.log = logging.getLogger("StatsClient")
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._tags = tags or {}
 
@@ -44,4 +46,7 @@ class StatsClient:
         for tag, tag_value in send_tags.items():
             parts.insert(1, ",{}={}".format(tag, tag_value).encode("utf-8"))
 
-        self._socket.sendto(b"".join(parts), self._dest_addr)
+        try:
+            self._socket.sendto(b"".join(parts), self._dest_addr)
+        except OSError as ex:
+            self.log.info("Stats UDP send failed: %s", ex)


### PR DESCRIPTION
Prevent journalpump from getting stuck when an exception is raised. Previously, an exception which was not caught, would cause journalpump to get stuck, since the sender threads are not stopped, and they are not marked with daemon=True. Mark them as daemon, so that the main thread quitting will cause the program to quit (and get restarted by systemd).
* Tested that the "Bad message on journal read" and "OSError on stats socket write" exceptions now cause termination, not stuckness
* Tested that journalpump shutdown is still clean; the main thread will quit after websocket & kafka senders have stopped

Also catch the stats socket write error - it may happen frequently when the receiving UDP service is restarted and not available for a few seconds.