### PR TITLE
elasticsearch,opensearch: Add fields for index mapping

### DIFF
--- a/journalpump/senders/elasticsearch_opensearch_sender.py
+++ b/journalpump/senders/elasticsearch_opensearch_sender.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass
 from http import HTTPStatus
 from io import BytesIO
@@ -17,6 +17,22 @@ import time
 class SenderType(enum.Enum):
     opensearch = "opensearch"
     elasticsearch = "elasticsearch"
+
+
+@dataclass(frozen=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    def __str__(self) -> str:
+        return f"version: {self.major}.{self.minor}.{self.patch}"
+
+    @staticmethod
+    def from_json(response_json: Dict[str, Any]) -> "Version":
+        version_number = str(response_json["version"]["number"])  # help mypy here
+        m, mi, p = tuple(map(int, version_number.split(".")))
+        return Version(major=m, minor=mi, patch=p)
 
 
 @dataclass(frozen=True)
@@ -49,7 +65,7 @@ class Config:
         )
 
 
-class _EsOsLogSenderBase(ABC, LogSender):
+class _EsOsLogSenderBase(LogSender):
 
     _DEFAULT_MAX_SENDER_INTERVAL = 10.0
 
@@ -70,6 +86,7 @@ class _EsOsLogSenderBase(ABC, LogSender):
         self._session.verify = self.config.get("ca", True)
         self._indices: Set[str] = set()
         self._last_es_error: Union[RequestsConnectionError, RequestsTimeout, None] = None
+        self._version: Union[Version, None] = None
 
     @property
     def _indices_url(self) -> str:
@@ -80,6 +97,9 @@ class _EsOsLogSenderBase(ABC, LogSender):
             return True
         self.mark_disconnected()
         try:
+            if not self._version:
+                version_response = self._session.get(self._config.request_url(""))
+                self._version = Version.from_json(version_response.json())
             self._indices = set(self._session.get(self._indices_url).json().keys())
             self._last_es_error = None
         except (RequestsConnectionError, RequestsTimeout) as ex:
@@ -96,7 +116,7 @@ class _EsOsLogSenderBase(ABC, LogSender):
             self.stats.unexpected_exception(ex, where="es_pump_init_es_client")
             return False
 
-        self.log.info("Initialized Index Aware HTTP connection")
+        self.log.info("Initialized %s HTTP connection", self._config.sender_type.value)
         self.mark_connected()
         return True
 
@@ -148,7 +168,7 @@ class _EsOsLogSenderBase(ABC, LogSender):
                 # ISO datetime first 10 characters are equivalent to the date we need i.e. '2018-04-14'
                 idx_name = f"""{self._config.index_name}-{message["timestamp"][:10]}"""
                 if idx_name not in self._indices:
-                    self._create_index_and_mapping(idx_name)
+                    self._create_index_and_mapping(index_name=idx_name, message=message)
 
                 self.format_message_for_es(buf=buf, header=self._message_header(idx_name), message=msg)
 
@@ -195,51 +215,19 @@ class _EsOsLogSenderBase(ABC, LogSender):
 
         return True
 
-    @abstractmethod
-    def _create_index_and_mapping(self, index_name: str) -> None:
-        raise NotImplementedError("_create_index_and_mapping hasn't been implemented")
-
-    @abstractmethod
-    def _message_header(self, index_name: str) -> Dict[str, Any]:
-        raise NotImplementedError("_message_header hasn't been implemented")
-
-
-class ElasticsearchSender(_EsOsLogSenderBase):
-    def __init__(self, *, config, **kwargs) -> None:
-        super().__init__(
-            sender_config=Config.create(sender_type=SenderType.elasticsearch, config=config),
-            config=config,
-            **kwargs,
-        )
-
     def _message_header(self, index_name: str) -> Dict[str, Any]:
         return {
             "index": {
                 "_index": index_name,
-                "_type": "journal_msg",
             }
         }
 
-    def _create_index_and_mapping(self, index_name: str) -> None:
+    def _create_index_and_mapping(self, *, index_name: str, message: Dict[str, Any]) -> None:
         try:
             self.log.info("Creating index: %r", index_name)
             res = self._session.put(
-                self._config.request_url(f"{index_name}?include_type_name=true"),
-                json={
-                    "mappings": {
-                        "journal_msg": {
-                            "properties": {
-                                "SYSTEMD_SESSION": {
-                                    "type": "text"
-                                },
-                                "SESSION_ID": {
-                                    "type": "text"
-                                },
-                            }
-                        }
-                    },
-                },
-                timeout=self._config.request_timeout * 2,
+                self._config.request_url(index_name),
+                json=self._create_mapping(message),
             )
             if res.status_code in self._SUCCESS_HTTP_STATUSES or "already_exists_exception" in res.text:
                 self._indices.add(index_name)
@@ -251,6 +239,79 @@ class ElasticsearchSender(_EsOsLogSenderBase):
             self.log.error("Problem creating index %r: %s: %s", index_name, ex.__class__.__name__, ex)
             self.stats.unexpected_exception(ex, where="es_pump_create_index_and_mappings")
             self._backoff()
+
+    def _create_mapping(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "mappings": {
+                "properties": {
+                    "SYSTEMD_SESSION": {
+                        "type": "text"
+                    },
+                    "SESSION_ID": {
+                        "type": "text"
+                    },
+                    **self._message_fields(message),
+                },
+            },
+        }
+
+    def _message_fields(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        addition_fields: Dict[str, Any] = {}
+        unmapped_fields = {}
+        for k, v in message.items():
+            if k == "timestamp":  # skip timestamp
+                continue
+            if isinstance(v, bool):
+                addition_fields[k] = {"type": "boolean"}
+            elif isinstance(v, float):
+                addition_fields[k] = {"type": "float"}
+            elif isinstance(v, int):
+                addition_fields[k] = {"type": "integer"}
+            elif isinstance(v, str):
+                addition_fields[k] = {"type": "text"}
+            elif isinstance(v, dict):
+                addition_fields[k] = {"properties": self._message_fields(v)}
+            else:
+                unmapped_fields[k] = type(v)
+                continue
+        if unmapped_fields:
+            self.log.warning("Unmapped fields: %s", unmapped_fields)
+        return addition_fields
+
+
+class ElasticsearchSender(_EsOsLogSenderBase):
+
+    _VERSION_WITH_MAPPING_TYPE_SUPPORT = 7
+
+    _LEGACY_TYPE = "journal_msg"
+
+    def __init__(self, *, config, **kwargs) -> None:
+        super().__init__(
+            sender_config=Config.create(sender_type=SenderType.elasticsearch, config=config),
+            config=config,
+            **kwargs,
+        )
+
+    def _message_header(self, index_name: str) -> Dict[str, Any]:
+        header = super()._message_header(index_name)
+        if not self._version:
+            raise ValueError("Version has not been set")
+        if self._version.major <= self._VERSION_WITH_MAPPING_TYPE_SUPPORT:
+            header["index"].update({"_type": self._LEGACY_TYPE})
+        return header
+
+    def _create_mapping(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        mapping = super()._create_mapping(message)
+        if not self._version:
+            raise ValueError("Version has not been set")
+        if self._version.major <= self._VERSION_WITH_MAPPING_TYPE_SUPPORT:
+            mapping["mappings"].update({
+                self._LEGACY_TYPE: {
+                    "properties": deepcopy(mapping["mappings"]["properties"])
+                },
+            })
+            del mapping["mappings"]["properties"]
+        return mapping
 
 
 class OpenSearchSender(_EsOsLogSenderBase):
@@ -260,39 +321,3 @@ class OpenSearchSender(_EsOsLogSenderBase):
             config=config,
             **kwargs,
         )
-
-    def _message_header(self, index_name: str) -> Dict[str, Any]:
-        return {
-            "index": {
-                "_index": index_name,
-            }
-        }
-
-    def _create_index_and_mapping(self, index_name: str) -> None:
-        try:
-            self.log.info("Creating index: %r", index_name)
-            res = self._session.put(
-                self._config.request_url(index_name),
-                json={
-                    "mappings": {
-                        "properties": {
-                            "SYSTEMD_SESSION": {
-                                "type": "text"
-                            },
-                            "SESSION_ID": {
-                                "type": "text"
-                            },
-                        }
-                    },
-                },
-            )
-            if res.status_code in self._SUCCESS_HTTP_STATUSES or "already_exists_exception" in res.text:
-                self._indices.add(index_name)
-            else:
-                self.mark_disconnected(f"""Cannot create index "{index_name}" ({res.status_code} {res.text})""")
-                self.log.warning("Could not create index mappings for: %r, %r %r", index_name, res.text, res.status_code)
-        except (RequestsConnectionError, RequestsTimeout) as ex:
-            self.mark_disconnected(ex)
-            self.log.error("Problem creating index %r: %s: %s", index_name, ex.__class__.__name__, ex)
-            self.stats.unexpected_exception(ex, where="es_pump_create_index_and_mappings")
-            self._backoff()

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -766,25 +766,71 @@ def test_journalpump_state_file(tmpdir):
 @responses.activate
 def test_es_sender():
     url = "http://localhost:1234"
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, url + "/_aliases", json={})
-        rsps.add(responses.POST, url + "/journalpump-2019-10-07/_bulk")
-        es = ElasticsearchSender(
-            name="es", reader=mock.Mock(), stats=mock.Mock(), field_filter=None, config={"elasticsearch_url": url}
-        )
-        assert es.send_messages(messages=[b'{"timestamp": "2019-10-07 14:00:00"}'], cursor=None)
+    responses.add(
+        responses.Response(
+            method=responses.GET,
+            url=f"{url}",
+            json={
+                "name": "eeee",
+                "cluster_name": "im_cluster",
+                "version": {
+                    "number": "7.10.2"
+                }
+            },
+        ),
+    )
+    responses.add(
+        responses.Response(
+            method=responses.GET,
+            url=f"{url}/_aliases",
+            json={},
+        ),
+    )
+    responses.add(
+        responses.Response(
+            method=responses.POST,
+            url=f"{url}/journalpump-2019-10-07/_bulk",
+        ),
+    )
+    es = ElasticsearchSender(
+        name="es", reader=mock.Mock(), stats=mock.Mock(), field_filter=None, config={"elasticsearch_url": url}
+    )
+    assert es.send_messages(messages=[b'{"timestamp": "2019-10-07 14:00:00"}'], cursor=None)
 
 
 @responses.activate
 def test_os_sender():
     url = "http://localhost:1234"
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, url + "/_aliases", json={})
-        rsps.add(responses.POST, url + "/journalpump-2019-10-07/_bulk")
-        opensearch_sender = OpenSearchSender(
-            name="os", reader=mock.Mock(), stats=mock.Mock(), field_filter=None, config={"opensearch_url": url}
-        )
-        assert opensearch_sender.send_messages(messages=[b'{"timestamp": "2019-10-07 14:00:00"}'], cursor=None)
+    responses.add(
+        responses.Response(
+            method=responses.GET,
+            url=f"{url}",
+            json={
+                "name": "oooo",
+                "cluster_name": "im_cluster",
+                "version": {
+                    "number": "1.2.4"
+                }
+            },
+        ),
+    )
+    responses.add(
+        responses.Response(
+            method=responses.GET,
+            url=f"{url}/_aliases",
+            json={},
+        ),
+    )
+    responses.add(
+        responses.Response(
+            method=responses.POST,
+            url=f"{url}/journalpump-2019-10-07/_bulk",
+        ),
+    )
+    opensearch_sender = OpenSearchSender(
+        name="os", reader=mock.Mock(), stats=mock.Mock(), field_filter=None, config={"opensearch_url": url}
+    )
+    assert opensearch_sender.send_messages(messages=[b'{"timestamp": "2019-10-07 14:00:00"}'], cursor=None)
 
 
 def test_awscloudwatch_sender():


### PR DESCRIPTION
- Add support ES 8.x and keep backward compatibility for ES 6.x
- Add index auto-mapping for fields in a message, so if JSON message has fields they will be
  mapped automatically to the index mapping. Supported python types:
    - str
    - boolean
    - int
    - float
    - dict