### PR TITLE
Changed senders to be lazy loaded

### DIFF
--- a/journalpump/senders/__init__.py
+++ b/journalpump/senders/__init__.py
@@ -1,9 +1,34 @@
-from .aws_cloudwatch import AWSCloudWatchSender  # noqa: F401
-from .elasticsearch_opensearch_sender import ElasticsearchSender  # noqa: F401
-from .elasticsearch_opensearch_sender import OpenSearchSender  # noqa: F401
-from .file import FileSender  # noqa: F401
-from .google_cloud_logging import GoogleCloudLoggingSender  # noqa: F401
-from .kafka import KafkaSender  # noqa: F401
-from .logplex import LogplexSender  # noqa: F401
-from .rsyslog import RsyslogSender  # noqa: F401
-from .websocket import WebsocketSender  # noqa: F401
+from typing import Any, Dict
+
+import importlib
+
+# config name <--> class mapping
+output_type_to_sender_class_path: Dict[str, str] = {
+    "aws_cloudwatch": "journalpump.senders.aws_cloudwatch.AWSCloudWatchSender",
+    "elasticsearch": "journalpump.senders.elasticsearch_opensearch_sender.ElasticsearchSender",
+    "opensearch": "journalpump.senders.elasticsearch_opensearch_sender.OpenSearchSender",
+    "file": "journalpump.senders.file.FileSender",
+    "google_cloud_logging": "journalpump.senders.google_cloud_logging.GoogleCloudLoggingSender",
+    "kafka": "journalpump.senders.kafka.KafkaSender",
+    "logplex": "journalpump.senders.logplex.LogplexSender",
+    "rsyslog": "journalpump.senders.rsyslog.RsyslogSender",
+    "websocket": "journalpump.senders.websocket.WebsocketSender",
+}
+
+# mapping to actual classes; primarily used by tests but used as cache here too
+output_type_to_sender_class: Dict[str, Any] = {}
+
+
+def get_sender_class(output_type):
+    sender_class = output_type_to_sender_class.get(output_type, None)
+    if sender_class is None:
+        try:
+            sender_class_path = output_type_to_sender_class_path[output_type]
+        except KeyError as ex:
+            raise Exception("Unknown sender type {!r}".format(output_type)) from ex
+
+        sender_class_module, sender_class_name = sender_class_path.rsplit(".", 1)
+        sender_module = importlib.import_module(sender_class_module)
+        sender_class = getattr(sender_module, sender_class_name)
+        output_type_to_sender_class[output_type] = sender_class
+    return sender_class

--- a/systest/test_rotation.py
+++ b/systest/test_rotation.py
@@ -1,4 +1,5 @@
 from .util import journalpump_initialized
+from journalpump import senders
 from journalpump.journalpump import JournalPump, JournalReader, PumpReader, statsd
 from journalpump.senders.base import MsgBuffer
 from pathlib import Path
@@ -160,7 +161,7 @@ def fixture_journalpump_factory(mocker, tmp_path, journal_log_dir):
 
         mocker.patch.object(PumpReader, "has_persistent_files", return_value=True)
         mocker.patch.object(PumpReader, "has_runtime_files", return_value=True)
-        mocker.patch.object(JournalReader, "sender_classes", {"stub_sender": sender})
+        senders.output_type_to_sender_class["stub_sender"] = sender
 
         config_path = tmp_path / "journalpump.json"
         with open(config_path, "w") as fp:

--- a/test/test_google_cloud_logging.py
+++ b/test/test_google_cloud_logging.py
@@ -1,7 +1,7 @@
 from .data import GCP_PRIVATE_KEY
 from googleapiclient.http import RequestMockBuilder as GoogleApiClientRequestMockBuilder
 from httplib2 import Response as HttpLib2Response
-from journalpump.senders import GoogleCloudLoggingSender
+from journalpump.senders.google_cloud_logging import GoogleCloudLoggingSender
 from typing import Dict, List
 from unittest import mock
 

--- a/test/test_websocket.py
+++ b/test/test_websocket.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 from collections import deque
 from journalpump.journalpump import JournalPump
-from journalpump.senders import WebsocketSender
+from journalpump.senders.websocket import WebsocketSender
 
 import asyncio
 import json


### PR DESCRIPTION
- Changes number of default imports (when running journalpump -h) from 862 to 307.

- Minimum RSS for actually journalpump doing work goes 58MB -> 35MB