### PR TITLE
journalpump: fix case where unit_log_level config is empty list

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -587,6 +587,10 @@ class UnitLogLevel:
             # If entry does not contain unit or priority we return it as is
             return data
 
+        if not self.levels:
+            # if the config is empty we return as is
+            return data
+
         if self._unit_match_level_glob(unit=unit, priority=priority):
             return data
 

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -591,6 +591,12 @@ class TestUnitLogLevels(TestCase):
         data = {"Foo": "bar", "PRIORITY": LOG_SEVERITY_MAPPING[log_level], "SYSTEMD_UNIT": "unit-b"}
         assert ll.filter_by_level(data) == {}
 
+    def test_empty_log_levels(self):
+        log_level = "INFO"
+        ll = UnitLogLevel("test", [])
+        data = {"Foo": "bar", "PRIORITY": LOG_SEVERITY_MAPPING[log_level], "SYSTEMD_UNIT": "unit-b"}
+        assert ll.filter_by_level(data) == data
+
     def test_matching_level(self):
         log_level = "INFO"
         ll = UnitLogLevel("test", [{"service_glob": "unit-a", "log_level": log_level}])


### PR DESCRIPTION
if unit_log_level configuration is an empty list, journalpump excludes all logs and does not ship any to a sender. this PR makes it ignore filtering if there is no config