### PR TITLE
Capture configuration errors more cleanly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,8 @@ Enables metrics sending to a statsd daemon that supports the influxdb-statsd
 
 The ``tags`` setting can be used to enter optional tag values for the metrics.
 
+The ``prefix`` setting can be used to enter an optional prefix for all metric names.
+
 Metrics sending follows the `Telegraf spec`_.
 
 .. _`Telegraf spec`: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,7 @@ Example::
       "statsd":   {
           "host": "127.0.0.1",
           "port": 12345,
+          "prefix": "user-",
           "tags": {
               "sometag": "somevalue"
           }

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -811,9 +811,7 @@ class JournalPump(ServiceDaemon, Tagged):
         """Called by ServiceDaemon when config has changed"""
         stats = self.config.get("statsd") or {}
         self.stats = statsd.StatsClient(
-            host=stats.get("host"),
-            port=stats.get("port"),
-            tags=stats.get("tags"),
+            host=stats.get("host"), port=stats.get("port"), tags=stats.get("tags"), prefix=stats.get("prefix", "")
         )
         self.replace_tags(self.config.get("tags", {}))
         geoip_db_path = self.config.get("geoip_database")

--- a/journalpump/senders/aws_cloudwatch.py
+++ b/journalpump/senders/aws_cloudwatch.py
@@ -10,7 +10,11 @@ MAX_INIT_TRIES = 3
 
 class AWSCloudWatchSender(LogSender):
     def __init__(self, *, config, aws_cloudwatch_logs=None, **kwargs):
-        super().__init__(config=config, max_send_interval=config.get("max_send_interval", 0.3), **kwargs)
+        super().__init__(
+            config=config,
+            max_send_interval=config.get("max_send_interval", 0.3),
+            **kwargs,
+        )
         self._logs = aws_cloudwatch_logs
         self.log_group = self.config.get("aws_cloudwatch_log_group")
         self.log_stream = self.config.get("aws_cloudwatch_log_stream")


### PR DESCRIPTION
This PR improves how metrics are emitted for tracking invalid configurations
* when configuration settings are invalid, the statsd gauge is periodically refreshed, allowing monitoring tools to more easily track the problem.
* invalid configuration settings will not cause the service to restart, though the new configuration file will be parsed when detected.
* The journalpump configuration file supports an optional statsd `prefix` value. This will be prepended to all metric names.