### PR TITLE
fix: tighten up tag sanitization

### DIFF
--- a/systest/test_rotation.py
+++ b/systest/test_rotation.py
@@ -115,9 +115,9 @@ class _MsgBuffer(MsgBuffer):
 
 
 class StubSender:
-    field_filter = None
-    unit_log_levels = None
-    extra_field_values = None
+    field_filter: Optional[dict] = None
+    unit_log_levels: Optional[dict] = None
+    extra_field_values: Optional[dict] = None
 
     def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
         self.msg_buffer = _MsgBuffer()

--- a/test/unit/senders/test_base.py
+++ b/test/unit/senders/test_base.py
@@ -1,0 +1,18 @@
+from journalpump.senders.base import Tagged
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input_tags,expected_output_tags",
+    [
+        ({"foo": "bar"}, {"foo": "bar"}),
+        ({"foo|wow,": "super!cool"}, {"foo_wow": "super!cool"}),
+        ({"host": "localhost:1234"}, {"host": "localhost_1234"}),
+        ({"base64": "YmFzZTY0Cg=="}, {"base64": "YmFzZTY0Cg"}),
+        ({"source_address": "127.0.0.1"}, {"source_address": "127.0.0.1"}),
+    ],
+)
+def test_tagged(input_tags: dict, expected_output_tags: dict):
+    tagged = Tagged(None)
+    assert tagged.make_tags(input_tags) == expected_output_tags


### PR DESCRIPTION
The tag sanitization introduced in
14a57be709cc9a5968918e0e25ea54f823c1fb5d was both too strict and too
loose. As per
https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels,
we need to make sure labels match the regexp `[a-zA-Z_:][a-zA-Z0-9_:]*`,
but `statsd` is more restrictive:
https://github.com/statsd/statsd/blob/9cf77d87855bcb69a8663135f59aa23825db9797/stats.js#L164-L172.

To solve this, lets have the tag names match strictly `[^\w_\-]+`.

For values, these can be typically any ASCII chars (as per Prometheus
above). However, the line protocol excludes the use of certain
characters, so lets ensure all characters that match `[\s\|=:]+` are
replaced.