### PR TITLE
fix search failing with TypeError on integers

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -536,6 +536,10 @@ class JournalReader(Tagged):
             tags = {}
             for field, regex in search["fields"].items():
                 line = entry.get(field, "")
+
+                if isinstance(line, int):
+                    line = str(line)
+
                 if not line:
                     all_match = False
                     break

--- a/scripts/generate_logs.py
+++ b/scripts/generate_logs.py
@@ -48,7 +48,10 @@ def _message_sender(uid: int, message_socket_path: str, queue: multiprocessing.J
     s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     s.connect(message_socket_path)
 
-    while msg := queue.get():
+    while True:
+        msg = queue.get()
+        if not msg:
+            break
         s.sendall(_encode_message(msg))
         queue.task_done()
 
@@ -182,7 +185,10 @@ def main():
 
     with JournalControlProcess(logs_dir=logs_dir, uid=uid) as journald_process:
 
-        while entry := input():
+        while True:
+            entry = input()
+            if not entry:
+                break
             action, *args = entry.strip().split(" ", 1)
 
             if action == "rotate":

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -315,7 +315,7 @@ def test_journal_reader_tagging(tmpdir):
     entry = JournalObject(
         entry={
             "MESSAGE": "CPU0: Core temperature above threshold, cpu clock throttled (total events = 1)",
-            "PRIORITY": "2",
+            "PRIORITY": 2,
             "SYSLOG_FACILITY": "0",
             "SYSLOG_IDENTIFIER": "kernel",
         }
@@ -335,7 +335,7 @@ def test_journal_reader_tagging(tmpdir):
     entry = JournalObject(
         entry={
             "MESSAGE": "CPU1: on fire",
-            "PRIORITY": "1",
+            "PRIORITY": 1,
             "SYSLOG_FACILITY": "0",
             "SYSLOG_IDENTIFIER": "kernel",
         }


### PR DESCRIPTION
Some journal entry items can be neither string nor bytes:
the PRIORITY field can be an int.

```
journalpump[2837]: journalpump           MainThread      ERROR     Unexpected exception while handling entry for host_stats
 Traceback (most recent call last):
   File "/usr/lib/python3.10/site-packages/journalpump/journalpump.py", line 884, in read_single_message
     return JournalObjectHandler(jobject, reader, self).process()
   File "/usr/lib/python3.10/site-packages/journalpump/journalpump.py", line 642, in process
     if not self.reader.perform_searches(self.jobject):
   File "/usr/lib/python3.10/site-packages/journalpump/journalpump.py", line 551, in perform_searches
     match = regex.search(line)
 TypeError: expected string or bytes-like object
```

Note: the coercion needs to be before the `if not line` to be able to match on zero with `^0$`.