### PR TITLE
Revert "rsyslog: mark some ssl errors as retriable"

### DIFF
--- a/journalpump/rsyslog.py
+++ b/journalpump/rsyslog.py
@@ -155,9 +155,6 @@ class SyslogTcpClient:
     def _should_retry(self, *, ex):
         if isinstance(ex, OSError):
             return ex.errno in (errno.EPIPE, errno.ECONNRESET, errno.ETIMEDOUT)
-        if isinstance(ex, ssl.SSLEOFError):
-            #  SSL connection has been terminated abruptly
-            return True
         return False
 
     def log(self, *, facility, severity, timestamp, hostname, program, pid=None, msgid=None, msg=None, sd=None):


### PR DESCRIPTION
This reverts commit 99345ea684ce74c782d8a3b32d38aadccc68e171.

It turned out `SSLEOFError` was not the cause of the issue, so no need to retry for this particular error. This doesn't seem like a recoverable one anyway so it makes sense to reinitialize right away when the rsyslog client if `SSLEOFError` happens