### PR TITLE
Skip secret match metric if nothing to report

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -328,6 +328,8 @@ class JournalReader(Tagged):
         now = time.monotonic()
         if (now - self.last_stats_send_time) < 10.0:
             return
+        if not self.secret_filter_matches:
+            return
         tags = self.make_tags()
         self.stats.increase("journal.secret_filter_match", self.secret_filter_matches, tags=tags)
         self.secret_filter_matches = 0


### PR DESCRIPTION
0.5% of our M3 metrics are this with zero.