### PR TITLE
remove boto3 dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ rpm:
 build-dep-fed:
 	sudo dnf -y --best --allowerasing install \
 		python3-flake8 python3-kafka python3-pytest python3-pylint \
-		python3-requests python3-responses systemd-python3 python3-boto3 \
+		python3-requests python3-responses systemd-python3 python3-botocore \
 		python3-websockets python3-aiohttp-socks python3-snappy \
 		python3-google-api-client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ requests
 websockets
 aiohttp-socks
 python-snappy
-boto3
+botocore
 google-api-python-client
 oauth2client
 geoip2

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -26,7 +26,7 @@ from journalpump.util import default_json_serialization
 from time import sleep
 from unittest import mock, TestCase
 
-import boto3
+import botocore.session
 import json
 import pytest
 import re
@@ -209,12 +209,14 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
     assert len(a.readers) == 1
     for rn, r in a.readers.items():
         assert rn == "foo"
-        with mock.patch("boto3.client", new=MockCloudWatch()) as mock_client, mock.patch.object(
+        mock_session = mock.MagicMock(spec=botocore.session.Session)
+        mock_session.create_client = mock.Mock(return_value=MockCloudWatch())
+        with mock.patch("botocore.session.get_session", return_value=mock_session), mock.patch.object(
             PumpReader, "has_persistent_files", return_value=True
         ):
             r.create_journald_reader_if_missing()
             assert len(r.senders) == 1
-            mock_client.assert_called_once_with(
+            mock_session.create_client.assert_called_once_with(
                 "logs",
                 region_name="us-east-1",
                 aws_access_key_id="key",
@@ -960,7 +962,8 @@ def test_os_sender():
 
 
 def test_awscloudwatch_sender():
-    logs = boto3.client("logs", region_name="us-east-1")
+    botocore_session = botocore.session.get_session()
+    logs = botocore_session.create_client("logs", region_name="us-east-1")
 
     with Stubber(logs) as stubber:
         stubber.add_client_error("create_log_group", service_error_code="ResourceAlreadyExistsException")
@@ -1070,7 +1073,8 @@ def test_awscloudwatch_sender():
 
 
 def test_awscloudwatch_sender_init():
-    logs = boto3.client("logs", region_name="us-east-1")
+    botocore_session = botocore.session.get_session()
+    logs = botocore_session.create_client("logs", region_name="us-east-1")
 
     # Test that AWSCloudWatchSender correctly raises SenderInitializationError after
     # aws_cloudwatch.MAX_INIT_TRIES attempts


### PR DESCRIPTION
botocore dependency is simpler for the use case of `journalpump` rather than using the boto3 wrapper. This makes it easier to use it along with other dependencies.