### PR TITLE
ci: support python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,26 @@ jobs:
     strategy:
       matrix:
         # only use oldest and newest version for the lint step
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.11"]
 
     steps:
 
       - id: checkout-code
         uses: actions/checkout@v2
 
+      - id: system-dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev libsnappy-dev
+
       - id: prepare-python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
-      - id: dependencies
+      - id: python-dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libsystemd-dev
+          python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements.dev.txt
 
@@ -43,23 +47,24 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, "3.10"]
+        python-version: ["3.9", "3.11"]
 
     steps:
       - id: checkout-code
         uses: actions/checkout@v2
+
+      - id: system-dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsystemd-dev libsnappy-dev
 
       - id: prepare-python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
-      - id: dependencies
+      - id: python-dependencies
         run: |
-          sudo apt-get update
-          # Setup build deps
-          sudo apt-get install -y libsystemd-dev
-          # Setup common python dependencies
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install --upgrade -r requirements.dev.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,13 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
--   repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.7.4
+-   repo: local
     hooks:
     -   id: pylint
-        args: [--disable=E0401]
+        name: pylint
+        entry: make pylint
+        language: system
+        types: [python]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.960
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 short_ver = 2.1.3
 long_ver = $(shell git describe --long 2>/dev/null || echo $(short_ver)-0-unknown-g`git describe --always`)
 
@@ -9,6 +10,10 @@ PYLINT_DIRS = journalpump/ test/ systest/
 .PHONY: unittest
 unittest:
 	$(PYTHON) -m pytest -vv test/
+
+.PHONY: pylint
+pylint:
+	$(PYTHON) -m pylint --rcfile .pylintrc $(PYLINT_DIRS) || exit $$(($$?&2))  # only fail on errors
 
 .PHONY: systest
 systest:

--- a/journalpump/senders/websocket.py
+++ b/journalpump/senders/websocket.py
@@ -12,7 +12,7 @@ import asyncio
 import contextlib
 import enum
 import logging
-import snappy
+import snappy  # pylint: disable=import-error
 import socket
 import ssl
 import time

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 # Use pip for build requirements to harmonize between OS versions
 mypy
-pylint>=2.4.3,<=2.7.2
+pylint
 pylint-quotes
 pytest
 pytest-cov==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: System :: Logging",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/test/test_websocket.py
+++ b/test/test_websocket.py
@@ -6,7 +6,7 @@ from journalpump.senders.websocket import WebsocketSender
 import asyncio
 import json
 import logging
-import snappy
+import snappy  # pylint: disable=import-error
 import threading
 import time
 import websockets
@@ -37,6 +37,7 @@ class WebsocketMockServer(threading.Thread):
 
     async def process_connection(self, websocket, path):
         self.log.info("WS: Client connection accepted on %s", path)
+        pending = set()
 
         try:
             incoming_websocket_task = asyncio.create_task(self.handle_incoming_websocket_message(connection=websocket))


### PR DESCRIPTION
the "standard" pylint action did not work for python 3.11 so replaced it with re-introduced `make pylint`.
Until full cleanup has been made only fail the build if pylint step finds Errors.
Mark the "known" import errors instead of blindly allowing all import errors unlike previously done in the commit hook implementation.