### PR TITLE
journalpump: sort readers' fields and check on MESSAGE as last

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -492,8 +492,11 @@ class JournalReader(Tagged):
             search.setdefault("tags", {})
             search.setdefault("fields", {})
             output = copy.deepcopy(search)
-            for name, pattern in output["fields"].items():
+            message_pattern = output["fields"].pop("MESSAGE", None)
+            for name, pattern in sorted(output["fields"].items()):
                 output["fields"][name] = re.compile(pattern)
+            if message_pattern:
+                output["fields"]["MESSAGE"] = re.compile(message_pattern)
 
             for tag, value in search["tags"].items():
                 if "(" in value or ")" in value:


### PR DESCRIPTION
At the moment, fields are sorted when serializing the config object. Here fields are sorted when initializing the JournalPump object and also the MESSAGE field is added as the last one to make the search operation to first evaluate conditions on the rest of the fields and thus evaluate the MESSAGE regexp only when necessary (for the sake of performance, since the MESSAGE field will be longer than the others).