### PR TITLE
config: handle missing match_value as described in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -302,6 +302,8 @@ defines the key to match against.
 
 If you want to match against a single journald field, this configuration key
 defines the value to match against.  Currently only equality is allowed.
+Note this means if you specify ``match_key`` and not ``match_value``, then the reader
+will match all entries that do not contain the ``match_key``.
 
 ``msg_buffer_max_length`` (default ``50000``)
 

--- a/journalpump/daemon.py
+++ b/journalpump/daemon.py
@@ -40,7 +40,7 @@ class ServiceDaemon:
         self.log = logging.getLogger(self.name)
         self.config_path = config_path
         self.config_file_ctime = None
-        self.config = None
+        self.config = {}
         self.require_config = require_config
         self.reload_config()
         self.running = True

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -901,7 +901,7 @@ class JournalPump(ServiceDaemon, Tagged):
     def check_match(self, entry):
         if not self.config.get("match_key"):
             return True
-        if entry.get(self.config["match_key"]) == self.config["match_value"]:
+        if entry.get(self.config["match_key"]) == self.config.get("match_value"):
             return True
         return False
 


### PR DESCRIPTION
In the docs it says we default to null for `match_value`, however we
actually throw. This makes us gracefully handle that input as described, and updates the docs to explicitly describe that behaviour.