### PR TITLE
update rsyslog TLS config

### DIFF
--- a/journalpump/rsyslog.py
+++ b/journalpump/rsyslog.py
@@ -97,6 +97,7 @@ class SyslogTcpClient:
             protocol = "PLAINTEXT"
         if cacerts is not None or protocol == "SSL":
             self.ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+            self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
             self.ssl_context.verify_mode = ssl.CERT_REQUIRED
             if cacerts:
                 self.ssl_context.load_verify_locations(cacerts)


### PR DESCRIPTION
Create a default ssl context with minimum_version set to TLSv1.2. This should be nearly universally compatible and provide the best baseline level of security/compliance

`ssl.create_default_context()` is used since we require > python3.9; 
> ssl.create_default_context - a convenience function, supported in Python 3.4 and later versions.
Even when you use these alternatives, you should ensure that a safe protocol is used. The following code illustrates how to use flags (available since Python 3.2) or the `minimum_version` field (favored since Python 3.7) to restrict the protocols accepted when creating a connection. 