### PR TITLE
reader: correctly only emit zeros once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 /.cache/
 /.coverage
+/.hypothesis
 /.vscode/
 /build/
 /dist/

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -311,8 +311,9 @@ class JournalReader(Tagged):
         These values will be periodically re-sent, ensuring the value
         is not discarded by the statsd server.
         """
+        old_value, _ = self.persistent_gauges.get(metric, (-1, {}))  # Get the old value, using a non-zero placeholder
         self.persistent_gauges[metric] = (value, tags)
-        if not value:
+        if value == 0 and old_value != 0:
             # Zeros won't be resent by the loop so we send them only once.
             self.stats.gauge(metric, value=value, tags=tags)
 

--- a/test/unit/reader/test_stats.py
+++ b/test/unit/reader/test_stats.py
@@ -1,0 +1,25 @@
+from journalpump import statsd
+from journalpump.journalpump import JournalReader
+from unittest.mock import Mock
+
+
+def test_persistent_gauge() -> None:
+    stats = Mock(spec=statsd.StatsClient)
+    reader = JournalReader(
+        name="foo",
+        config={},
+        field_filters={},
+        geoip=None,
+        stats=stats,
+        searches=[],
+    )
+
+    reader.set_persistent_gauge(metric="test", value=0, tags={})
+    reader.set_persistent_gauge(metric="test", value=0, tags={})
+    stats.gauge.assert_called_once()
+    stats.reset_mock()
+    reader.set_persistent_gauge(metric="test", value=1, tags={})
+    reader.set_persistent_gauge(metric="test", value=2, tags={})
+    stats.gauge.assert_not_called()
+    reader.set_persistent_gauge(metric="test", value=0, tags={})
+    stats.gauge.assert_called_once()


### PR DESCRIPTION
https://github.com/aiven/journalpump/pull/140 Intended to limit 0 metric values to only be emitted once, but it didn't check if the preceding value was zero so continued emission of 0 could occur.