### PR TITLE
senders: migrate from oauth2client to google-auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,14 @@ build-dep-fed:
 		python3-flake8 python3-kafka python3-pytest python3-pylint \
 		python3-requests python3-responses systemd-python3 python3-botocore \
 		python3-websockets python3-aiohttp-socks python3-snappy \
-		python3-google-api-client
+		python3-google-api-client python3-google-auth
 
 build-dep-deb:
 	sudo apt-get install \
 		build-essential devscripts dh-systemd \
 		python-all python-setuptools python3-systemd python3-kafka \
 		python3-websockets python3-aiohttp-socks python3-snappy \
-		python3-botocore python3-googleapi
+		python3-botocore python3-googleapi python3-google-auth
 
 
 .PHONY: rpm

--- a/journalpump.spec
+++ b/journalpump.spec
@@ -6,7 +6,7 @@ Summary:        Pump messages from systemd journal to Elasticsearch, Kafka, Logp
 License:        ASL 2.0
 Source0:        journalpump-rpm-src.tar.gz
 Requires:       python3-kafka, systemd-python3, python3-requests, python3-botocore, python3-google-api-client
-Requires:       python3-oauth2client, python3-geoip2, python3-typing-extensions
+Requires:       python3-google-auth, python3-geoip2, python3-typing-extensions
 Requires:	python3-websockets, python3-aiohttp-socks, python3-snappy
 BuildRequires:  python3-kafka, systemd-python3, python3-requests, python3-botocore, python3-google-api-client
 BuildRequires:  python3-devel, python3-pytest, python3-pylint python3-responses

--- a/journalpump/senders/google_cloud_logging.py
+++ b/journalpump/senders/google_cloud_logging.py
@@ -1,7 +1,8 @@
 from .base import LogSender
+from google.auth import default as get_application_default
+from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import Error as GoogleApiClientError
-from oauth2client.service_account import ServiceAccountCredentials
 
 import contextlib
 import json
@@ -30,10 +31,10 @@ class GoogleCloudLoggingSender(LogSender):
         self.log_id = config["google_cloud_logging_log_id"]
         self.resource_labels = config.get("google_cloud_logging_resource_labels", None)
         if google_service_account:
-            credentials = ServiceAccountCredentials.from_json_keyfile_dict(google_service_account)
-            self.project_id = google_service_account["project_id"]
+            credentials = Credentials.from_service_account_info(google_service_account)
+            self.project_id = credentials.project_id
         else:
-            credentials = ServiceAccountCredentials.get_application_default()
+            credentials = get_application_default()
 
         if googleapiclient_request_builder is not None:
             self._logs = build(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp-socks
 python-snappy
 botocore
 google-api-python-client
-oauth2client
+google-auth
 geoip2
 https://github.com/systemd/python-systemd/zipball/master
 typing-extensions

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "aiohttp-socks",
         "botocore",
         "google-api-python-client",
-        "oauth2client",
+        "google-auth",
         "geoip2",
         "typing-extensions",
     ],


### PR DESCRIPTION
The oauth2client was deprecated in 2019 and has not received any updates ever since. In particular, it does not support the `universe_domain` option.

> Note: oauth2client is now deprecated. No more features will be added to the
  libraries and the core team is turning down support. We recommend you use
  google-auth and oauthlib. For more details on the deprecation,
  see oauth2client deprecation.