### PR TITLE
Updating version and NEWS with last updates since version 2.4.3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+journalpump 2.5.0 (2023-11-20)
+==============================
+* Migrate From oauth2client to google-auth
+* Improved error handling for AWS Cloudwatch sender
+* Logging improvements for multiple senders
+
 journalpump 2.4.3 (2022-04-21)
 ==============================
 * Add a feature for secret/credential filtering by regular expressions

--- a/journalpump/__init__.py
+++ b/journalpump/__init__.py
@@ -3,4 +3,4 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 """journalpump"""
-__version__ = "2.4.3"
+__version__ = "2.5.0"


### PR DESCRIPTION
Creating a release version of journal pump.
There have been tags created for 2.4.4 & 2.4.5 but they have not updated the version in __init__.py 
This will upgrade the release version and can be tagged as a release of journalpump.
Also the NEWS has been updated to include all changes since tag 2.4.3