### PR TITLE
Make rsyslog max message size configurable

### DIFF
--- a/journalpump/rsyslog.py
+++ b/journalpump/rsyslog.py
@@ -75,12 +75,12 @@ def _generate_format(logline):
 
 class SyslogTcpClient:
     def __init__(
-        self, *, server, port, rfc, max_msg=2048, protocol=None, cacerts=None, keyfile=None, certfile=None, log_format=None
+        self, *, server, port, rfc, max_msg=None, protocol=None, cacerts=None, keyfile=None, certfile=None, log_format=None
     ):
         self.socket = None
         self.server = server
         self.port = port
-        self.max_msg = max_msg
+        self.max_msg = max_msg or 2048
         self.socket_proto = socket.SOCK_STREAM
         self.ssl_context = None
         if rfc == "RFC5424":

--- a/journalpump/senders/rsyslog.py
+++ b/journalpump/senders/rsyslog.py
@@ -35,6 +35,7 @@ class RsyslogSender(LogSender):
                     server=server,
                     port=port,
                     rfc=self.config.get("format", "rfc5424").upper(),
+                    max_msg=self.config.get("max_message_size"),
                     protocol="SSL" if self.config.get("ssl") is True else "PLAINTEXT",
                     cacerts=self.config.get("ca_certs"),
                     keyfile=self.config.get("client_key"),


### PR DESCRIPTION
By default Rsyslog splits log messages at 8k, but journalpump has a hard-coded value of 2048, which it uses to truncate large messages that are sent to Rsyslog. This changes that so that supported message size is now configurable.