### PR TITLE
misc: use re2 if configured

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SHELL=/bin/bash
 short_ver = 2.1.3
 long_ver = $(shell git describe --long 2>/dev/null || echo $(short_ver)-0-unknown-g`git describe --always`)
 
+USE_RE2=${USE_RE2}
+
 all: py-egg
 
 PYTHON ?= python3

--- a/README.rst
+++ b/README.rst
@@ -370,6 +370,7 @@ Using backrefs, the message can also be restructured into a new format.
   }
 ]
 
+Secret filters and searches can be made to use re2 as a regex engine by running journalpump with the environment "USE_RE2=yes". Make sure that the PyPI package "google_re2" is installed with at least version 1.1
 
 ``secret_filter_metrics`` ( default: ``false``)
 Change this setting to true to emit metrics to the metrics host whenever a secret pattern is matched.

--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -17,10 +17,16 @@ import datetime
 import fnmatch
 import json
 import logging
-import re
+import os
 import select
 import time
 import uuid
+
+# NOTE: make sure to use google-re >= 1.1 if this is enabled.
+if os.environ.get("USE_RE2"):
+    import re2 as re
+else:
+    import re  # type: ignore[no-redef]
 
 _5_MB = 5 * 1024 * 1024
 CHUNK_SIZE = 5000

--- a/journalpump/senders/base.py
+++ b/journalpump/senders/base.py
@@ -2,10 +2,16 @@ from threading import Lock, Thread
 from typing import Dict, Optional
 
 import logging
+import os
 import random
-import re
 import sys
 import time
+
+# NOTE: make sure to use google-re >= 1.1
+if os.environ.get("USE_RE2"):
+    import re2 as re
+else:
+    import re  # type: ignore[no-redef]
 
 KAFKA_COMPRESSED_MESSAGE_OVERHEAD = 30
 MAX_KAFKA_MESSAGE_SIZE = 1024**2  # 1 MiB

--- a/journalpump/senders/elasticsearch_opensearch_sender.py
+++ b/journalpump/senders/elasticsearch_opensearch_sender.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Set, Union
 
 import enum
 import json
-import re
 import time
 
 
@@ -71,8 +70,6 @@ class Config:
 
 class _EsOsLogSenderBase(LogSender):
     _DEFAULT_MAX_SENDER_INTERVAL = 10.0
-
-    _INDICIES_URL_REDACTION_REGEXP = r"(\w*?://[A-Za-z0-9\-._~%!$&'()*+,;=]*)(:)([A-Za-z0-9\-._~%!$&'()*+,;=]*)(@)"
 
     _ONE_HOUR_LAST_INDEX_CHECK = 3600
 
@@ -173,8 +170,7 @@ class _EsOsLogSenderBase(LogSender):
         try:
             es_available = self._load_indices()
             if not es_available:
-                redacted_url = re.sub(self._INDICIES_URL_REDACTION_REGEXP, r"\1\2[REDACTED]\4", self._indices_url)
-                self.log.warning("Waiting for connection to %s for %s", redacted_url, self.name)
+                self.log.warning("Waiting for connection for %s", self.name)
                 self._backoff()
                 return False
             for msg in messages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ google-auth
 geoip2
 https://github.com/systemd/python-systemd/zipball/master
 typing-extensions
+google-re2

--- a/systest/test_rsyslog.py
+++ b/systest/test_rsyslog.py
@@ -13,10 +13,16 @@ import logging
 import logging.handlers
 import os
 import random
-import re
 import socket
 import string
 import threading
+
+# NOTE: make sure to use google-re >= 1.1 if this is enabled.
+if os.environ.get("USE_RE2"):
+    import re2 as re
+else:
+    import re  # type: ignore[no-redef]
+
 
 RSYSLOGD = "/usr/sbin/rsyslogd"
 

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -29,9 +29,15 @@ from unittest import mock, TestCase
 
 import botocore.session
 import json
+import os
 import pytest
-import re
 import responses
+
+# NOTE: make sure to use google-re >= 1.1 if this is enabled.
+if os.environ.get("USE_RE2"):
+    import re2 as re
+else:
+    import re  # type: ignore[no-redef]
 
 
 def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements


### PR DESCRIPTION
Make it possible to use re2 as a non-backtracking engine to evaluate searches. We make it opt-in, configurable using environment since otherwise it would constitute a breaking change. 