### PR TITLE
rsyslog: use ssl.create_default_context for secure TLS

### DIFF
--- a/journalpump/rsyslog.py
+++ b/journalpump/rsyslog.py
@@ -108,11 +108,8 @@ class SyslogTcpClient:
         if protocol is None:
             protocol = "PLAINTEXT"
         if cacerts is not None or protocol == "SSL":
-            self.ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+            self.ssl_context = ssl.create_default_context(cafile=cacerts)
             self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
-            self.ssl_context.verify_mode = ssl.CERT_REQUIRED
-            if cacerts:
-                self.ssl_context.load_verify_locations(cacerts)
             if certfile:
                 self.ssl_context.load_cert_chain(certfile, keyfile)
 


### PR DESCRIPTION
Replace manual ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT) with
ssl.create_default_context(), which is the Python-recommended
factory for creating secure TLS contexts. This resolves the
CodeQL py/insecure-protocol alert (CWE-327) as CodeQL recognizes
create_default_context as inherently safe.

This resolves the CodeQL alert for CWE-327 (use of a broken or
weak cryptographic algorithm).
