### PR TITLE
rsyslog: fix octet-counted framing on oversize messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -595,6 +595,14 @@ By default, log messages are sent using non-transparent framing and are terminat
 Set it to ``true`` if the server supports octet-counted framing and messages are multi-line.
 (see `RFC 6587 for Syslog over TCP message transfer <https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1>`_)
 
+``max_message_size`` (default ``2048``)
+
+Maximum size in bytes of the message body sent to the syslog server. Messages longer than this
+are truncated. With non-transparent framing the truncated body is terminated with a newline.
+With octet-counted framing the truncated body is wrapped in a ``<length> SP <body>`` frame
+whose length matches the actual body bytes sent (RFC 6587 section 3.4.1), so the stream
+framing is never corrupted by an oversize message.
+
 ``structured_data`` (default ``null``)
 
 Content of structured data section (optional, required by some services to identify the sender).

--- a/journalpump/rsyslog.py
+++ b/journalpump/rsyslog.py
@@ -147,29 +147,32 @@ class SyslogTcpClient:
         finally:
             self.socket = None
 
-    def send(self, message):
+    def send(self, message: bytes) -> None:
         for retry in [True, False]:
             try:
                 if self.socket is None:
                     self._connect()
+                assert self.socket is not None
 
-                # Syslog over TCP (RFC 6587) supports 2 message framing methods:
-                # - Octet-counted framing: Each message is prefixed with its
-                #     length and a space (<length> <message>).
-                # - Non-transparent framing: Each message is terminated by a
-                #     newline (\n).
-                # So far, only non-transparent framing was used by journalpump
-                # and multi-line log messages were terminated at first newline.
-                # We keep this behavior by default, but now expose a new config
-                # allowing to switch to octet-counted framing. Provided that this
-                # method is supported by the syslog server, multi-line messages
-                # will only get truncated according to the max_message_size.
+                # RFC 6587 defines two framing methods for syslog over TCP.
                 if self.octet_counted_framing:
-                    message = f"{len(message)} ".encode("utf-8") + message
-
-                self.socket.sendall(message[: self.max_msg - 1])
-                if len(message) >= self.max_msg:
-                    self.socket.sendall(b"\n")
+                    # Octet-counted framing (RFC 6587 section 3.4.1):
+                    # <MSGLEN> SP <SYSLOG-MSG>. The receiver reads exactly
+                    # <MSGLEN> bytes after the space, so the advertised length
+                    # must equal the body bytes actually sent. max_message_size
+                    # bounds the body (matching rsyslog MaxMessageSize semantics).
+                    # No trailing newline — it would be parsed as the start of
+                    # the next frame's length prefix and desync the stream.
+                    body = message[: self.max_msg]
+                    frame = f"{len(body)} ".encode("utf-8") + body
+                    self.socket.sendall(frame)
+                else:
+                    # Non-transparent framing (RFC 6587 section 3.4.2): frames
+                    # are delimited by a trailing newline. The formatter already
+                    # appends '\n'; when we truncate we add it explicitly.
+                    self.socket.sendall(message[: self.max_msg - 1])
+                    if len(message) >= self.max_msg:
+                        self.socket.sendall(b"\n")
 
                 break
             except Exception as ex:  # pylint: disable=broad-except

--- a/systest/test_rsyslog.py
+++ b/systest/test_rsyslog.py
@@ -116,6 +116,7 @@ def _run_pump_test(
     messages_to_send,
     expected_message_count,
     expected_multiline_support,
+    expected_subsequent_message=None,
 ):
     journalpump = None
     threads = []
@@ -156,6 +157,7 @@ def _run_pump_test(
     # Check the results
     found = 0
     multiline_support = False
+    subsequent_message_found = False
     with open(logfile, "r", encoding="utf-8") as fp:
         lines = fp.readlines()
     for txt in ["Info", "Warning", "Error", "Critical"]:
@@ -167,6 +169,16 @@ def _run_pump_test(
                 if txt == "Info":
                     multiline_support = line.endswith("example#012stack#012trace {%} -\n")
                 break
+    if expected_subsequent_message is not None:
+        subsequent_pattern = re.compile(rf".*{expected_subsequent_message} for {identifier}.*")
+        for line in lines:
+            if subsequent_pattern.match(line):
+                log.info("Found subsequent message: %s", line)
+                subsequent_message_found = True
+                break
+        assert (
+            subsequent_message_found
+        ), "Subsequent message not found — connection likely desynced after oversize octet-counted frame"
     assert found == expected_message_count, "Expected messages not found in syslog"
     assert (
         multiline_support == expected_multiline_support
@@ -174,7 +186,7 @@ def _run_pump_test(
 
 
 @pytest.mark.parametrize(
-    "messages_to_send,octet_counted_framing_config,expected_message_count,expected_multiline_support",
+    "messages_to_send,sender_config,expected_message_count,expected_multiline_support,expected_subsequent_message",
     [
         (
             [
@@ -192,6 +204,7 @@ def _run_pump_test(
             {},  # config not specified, octet_counted_framing is False by default
             4,
             False,
+            None,
         ),
         (
             [
@@ -203,6 +216,7 @@ def _run_pump_test(
             {"octet_counted_framing": False},
             1,
             False,
+            None,
         ),
         (
             [
@@ -214,15 +228,35 @@ def _run_pump_test(
             {"octet_counted_framing": True},
             1,
             True,
+            None,
+        ),
+        # Verify that an oversize octet-counted frame is truncated without desyncing the stream.
+        # A short subsequent message on the same connection must still be delivered correctly.
+        (
+            [
+                {
+                    "text": "Info message for {identifier}\n" + "X" * 300,
+                    "PRIORITY": journal.LOG_INFO,
+                },
+                {
+                    "text": "Critical message for {identifier}",
+                    "PRIORITY": journal.LOG_CRIT,
+                },
+            ],
+            {"octet_counted_framing": True, "max_message_size": 80},
+            2,
+            False,
+            "Critical message",
         ),
     ],
 )
 def test_rsyslogd_tcp_sender(
     tmpdir,
     messages_to_send,
-    octet_counted_framing_config,
+    sender_config,
     expected_message_count,
     expected_multiline_support,
+    expected_subsequent_message,
 ):
     workdir = tmpdir.dirname
     logfile = f"{workdir}/test.log"
@@ -239,7 +273,7 @@ def test_rsyslogd_tcp_sender(
                                 "rsyslog_port": 5140,
                                 "format": "custom",
                                 "logline": "<%pri%>%timestamp% %HOSTNAME% %app-name%[%procid%]: %msg% {%%} %not-valid-tag%",
-                                **dict(octet_counted_framing_config),
+                                **dict(sender_config),
                             },
                         },
                     },
@@ -256,6 +290,7 @@ def test_rsyslogd_tcp_sender(
             messages_to_send=messages_to_send,
             expected_message_count=expected_message_count,
             expected_multiline_support=expected_multiline_support,
+            expected_subsequent_message=expected_subsequent_message,
         )
     finally:
         rsyslogd.stop()

--- a/test/test_rsyslog.py
+++ b/test/test_rsyslog.py
@@ -1,0 +1,178 @@
+# Copyright 2019, Aiven, https://aiven.io/
+#
+# This file is under the Apache License, Version 2.0.
+# See the file `LICENSE` for details.
+from journalpump.rsyslog import SyslogTcpClient
+from unittest import mock
+
+import pytest
+
+
+class _StubSocket:
+    """Minimal socket stub that records bytes passed to sendall."""
+
+    def __init__(self) -> None:
+        self.sent = bytearray()
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.extend(data)
+
+    def close(self) -> None:
+        pass
+
+
+def _make_client(*, max_msg: int, octet_counted_framing: bool) -> tuple[SyslogTcpClient, _StubSocket]:
+    with mock.patch.object(SyslogTcpClient, "_connect"):
+        client = SyslogTcpClient(
+            server="127.0.0.1",
+            port=1,
+            rfc="RFC5424",
+            max_msg=max_msg,
+            octet_counted_framing=octet_counted_framing,
+        )
+    sock = _StubSocket()
+    client.socket = sock
+    return client, sock
+
+
+def _parse_octet_counted_frames(stream: bytes) -> list[bytes]:
+    """Parse an RFC 6587 octet-counted stream into individual message bodies."""
+    frames: list[bytes] = []
+    i = 0
+    while i < len(stream):
+        sp = stream.index(b" ", i)
+        n = int(stream[i:sp])
+        body = stream[sp + 1 : sp + 1 + n]
+        assert len(body) == n, f"stream desync at offset {i}: advertised {n} bytes, got {len(body)}"
+        frames.append(bytes(body))
+        i = sp + 1 + n
+    return frames
+
+
+class TestNonTransparentFraming:
+    """octet_counted_framing=False — must be byte-for-byte identical to the pre-fix behavior."""
+
+    def test_small_body_sent_verbatim(self):
+        body = b"<13>1 2024-01-01T00:00:00Z host app - - hello\n"
+        max_msg = len(body) + 10
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=False)
+
+        client.send(body)
+
+        assert bytes(sock.sent) == body
+
+    def test_small_body_no_extra_newline(self):
+        body = b"<13>1 2024-01-01T00:00:00Z host app - - hello\n"
+        max_msg = len(body) + 10
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=False)
+
+        client.send(body)
+
+        assert sock.sent.count(b"\n") == 1
+
+    def test_oversize_body_truncated_and_newline_appended(self):
+        body = b"A" * 200 + b"\n"
+        max_msg = 50
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=False)
+
+        client.send(body)
+
+        expected = body[: max_msg - 1] + b"\n"
+        assert bytes(sock.sent) == expected
+
+    def test_body_exactly_max_msg_triggers_truncation(self):
+        # len(body) == max_msg means the body >= max_msg branch fires
+        max_msg = 50
+        body = b"B" * max_msg
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=False)
+
+        client.send(body)
+
+        expected = body[: max_msg - 1] + b"\n"
+        assert bytes(sock.sent) == expected
+
+
+class TestOctetCountedFraming:
+    """octet_counted_framing=True — must produce RFC 6587 section 3.4.1 frames."""
+
+    def test_small_multiline_body_framed_correctly(self):
+        body = b"<13>1 2024-01-01T00:00:00Z host app - - line1\nline2\nline3\n"
+        max_msg = len(body) + 50
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=True)
+
+        client.send(body)
+
+        wire = bytes(sock.sent)
+        sp = wire.index(b" ")
+        advertised_len = int(wire[:sp])
+        sent_body = wire[sp + 1 :]
+
+        assert advertised_len == len(body)
+        assert sent_body == body
+
+    def test_small_body_no_trailing_newline_outside_frame(self):
+        body = b"<13>1 2024-01-01T00:00:00Z host app - - msg\n"
+        max_msg = len(body) + 50
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=True)
+
+        client.send(body)
+
+        wire = bytes(sock.sent)
+        sp = wire.index(b" ")
+        n = int(wire[:sp])
+        # Everything after the prefix+space+body must be empty (no stray newline)
+        assert len(wire) == sp + 1 + n
+
+    def test_oversize_body_truncated_and_prefix_matches(self):
+        body = b"X" * 300
+        max_msg = 100
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=True)
+
+        client.send(body)
+
+        wire = bytes(sock.sent)
+        sp = wire.index(b" ")
+        advertised_len = int(wire[:sp])
+        sent_body = wire[sp + 1 :]
+
+        assert advertised_len == len(sent_body)
+        assert len(sent_body) <= max_msg
+        assert sent_body == body[:max_msg]
+
+    def test_back_to_back_oversize_messages_no_desync(self):
+        """Two oversize messages on the same connection must parse without desync."""
+        body1 = b"<13>1 2024-01-01T00:00:00Z h a - - " + b"M" * 300 + b"\n"
+        body2 = b"<14>1 2024-01-01T00:00:01Z h b - - short\n"
+        max_msg = 60
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=True)
+
+        client.send(body1)
+        client.send(body2)
+
+        frames = _parse_octet_counted_frames(bytes(sock.sent))
+        assert len(frames) == 2
+        assert frames[0] == body1[:max_msg]
+        assert frames[1] == body2[:max_msg]
+
+    def test_very_small_max_msg_produces_self_consistent_frame(self):
+        """Even with max_msg=8 the frame prefix must equal the body length."""
+        body = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\n"
+        max_msg = 8
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=True)
+
+        client.send(body)
+
+        frames = _parse_octet_counted_frames(bytes(sock.sent))
+        assert len(frames) == 1
+        assert len(frames[0]) <= max_msg
+
+    @pytest.mark.parametrize("max_msg", [1, 4, 8, 16, 32])
+    def test_various_small_max_msg_always_self_consistent(self, max_msg: int):
+        body = b"Hello, multi\nline\nbody\n" * 5
+        client, sock = _make_client(max_msg=max_msg, octet_counted_framing=True)
+
+        client.send(body)
+
+        frames = _parse_octet_counted_frames(bytes(sock.sent))
+        assert len(frames) == 1
+        assert len(frames[0]) <= max_msg


### PR DESCRIPTION
When `octet_counted_framing` is enabled and the encoded message
exceeds `max_message_size`, the previous code advertised the full
body length in the frame prefix but only sent a truncated body
(plus a stray newline). RFC 6587 octet-counted receivers then
consumed bytes from the following frame to make up the count,
desyncing the entire connection.

Truncate the body before computing the prefix length, drop the
non-transparent newline in octet-counted mode, and document that
`max_message_size` bounds the body bytes in both modes.
