### PR TITLE
journalpump: inject __SEQNUM into journal entries

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -102,6 +102,17 @@ class PumpReader(journal.Reader):
 
         return output
 
+    @staticmethod
+    def _parse_seqnum_from_cursor(cursor) -> int | None:
+        # cursor format: s=...;i=<hex_seqnum>;b=...;m=...;t=...;x=...
+        for part in cursor.split(";"):
+            if part.startswith("i="):
+                try:
+                    return int(part[2:], 16)
+                except ValueError:
+                    return None
+        return None
+
     def get_next(self, skip=1):
         # pylint: disable=no-member, protected-access
         """Private get_next implementation that doesn't store the cursor since we don't want it"""
@@ -109,7 +120,11 @@ class PumpReader(journal.Reader):
             entry = super()._get_all()
             if entry:
                 entry["__REALTIME_TIMESTAMP"] = self._get_realtime()
-                return JournalObject(cursor=self._get_cursor(), entry=self.convert_entry(entry))
+                cursor = self._get_cursor()
+                seqnum = self._parse_seqnum_from_cursor(cursor)
+                if seqnum is not None:
+                    entry["__SEQNUM"] = seqnum
+                return JournalObject(cursor=cursor, entry=self.convert_entry(entry))
 
         return None
 

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -24,6 +24,7 @@ from journalpump.senders.logplex import LogplexSender
 from journalpump.senders.rsyslog import RsyslogSender
 from journalpump.types import LOG_SEVERITY_MAPPING
 from journalpump.util import default_json_serialization
+from systemd import journal
 from time import sleep
 from unittest import mock, TestCase
 
@@ -259,6 +260,50 @@ def test_journalpump_init(tmpdir):  # pylint: disable=too-many-statements
             s.running = False
             s.join()
             assert isinstance(s, GoogleCloudLoggingSender)
+
+
+def test_pump_reader_get_next_includes_seqnum():
+    reader = PumpReader()
+    cursor = "s=abc;i=1f4;b=def;m=123;t=456;x=789"
+    expected_seqnum = 0x1F4  # decimal 500
+    entry_data = {"MESSAGE": b"hello", "__REALTIME_TIMESTAMP": b"1000000"}
+
+    with (
+        mock.patch.object(journal.Reader, "_next", return_value=True),
+        mock.patch.object(journal.Reader, "_get_all", return_value=entry_data),
+        mock.patch.object(reader, "_get_realtime", return_value=1000000),
+        mock.patch.object(reader, "_get_cursor", return_value=cursor),
+    ):
+        result = reader.get_next()
+
+    assert result is not None
+    assert "__SEQNUM" in result.entry
+    assert result.entry["__SEQNUM"] == expected_seqnum
+    assert isinstance(result.entry["__SEQNUM"], int)
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        "s=abc;b=def;m=123;t=456;x=789",  # no i= field
+        "s=abc;i=;b=def;m=123;t=456;x=789",  # empty i= value
+        "s=abc;i=xyz;b=def;m=123;t=456;x=789",  # non-hex i= value
+    ],
+)
+def test_pump_reader_get_next_seqnum_missing_or_invalid(cursor):
+    reader = PumpReader()
+    entry_data = {"MESSAGE": b"hello", "__REALTIME_TIMESTAMP": b"1000000"}
+
+    with (
+        mock.patch.object(journal.Reader, "_next", return_value=True),
+        mock.patch.object(journal.Reader, "_get_all", return_value=entry_data),
+        mock.patch.object(reader, "_get_realtime", return_value=1000000),
+        mock.patch.object(reader, "_get_cursor", return_value=cursor),
+    ):
+        result = reader.get_next()
+
+    assert result is not None
+    assert "__SEQNUM" not in result.entry
 
 
 def test_journal_reader_tagging(tmpdir):


### PR DESCRIPTION
To get the log sequence number, to use it after in sort order.

Parse the sequence number from the i= field of the journald cursor string and include it as an integer under __SEQNUM in each entry returned by PumpReader.get_next(). This allows downstream consumers to use it as a secondary sort key for log lines sharing the same microsecond timestamp (e.g. MySQL crash stack traces).

No direct API exists on the systemd.journal.Reader C extension for sequence numbers, so the cursor string is the only available source, consistent with how __REALTIME_TIMESTAMP is injected via _get_realtime().