### PR TITLE
Bump kafka-python dependency to support 2.3.1

### DIFF
--- a/journalpump/senders/kafka_sender.py
+++ b/journalpump/senders/kafka_sender.py
@@ -2,6 +2,7 @@ from .base import LogSender
 from kafka import errors, KafkaAdminClient, KafkaProducer
 from kafka.admin import NewTopic
 
+import inspect
 import logging
 import socket
 
@@ -15,7 +16,23 @@ try:
 except ImportError:
     zstd = None
 
-KAFKA_CONN_ERRORS = tuple(errors.RETRY_ERROR_TYPES) + (
+
+def _get_retriable_kafka_errors():
+    """Build the set of retriable Kafka error types.
+
+    kafka-python < 2.1 provides errors.RETRY_ERROR_TYPES.
+    kafka-python >= 2.1 marks individual error classes with retriable = True.
+    """
+    if hasattr(errors, "RETRY_ERROR_TYPES"):
+        return tuple(errors.RETRY_ERROR_TYPES)
+    return tuple(
+        obj
+        for _name, obj in inspect.getmembers(errors)
+        if inspect.isclass(obj) and issubclass(obj, errors.KafkaError) and getattr(obj, "retriable", False)
+    )
+
+
+KAFKA_CONN_ERRORS = _get_retriable_kafka_errors() + (
     errors.UnknownError,
     socket.timeout,
     TimeoutError,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kafka-python<2.0.4
+kafka-python<2.4.0
 requests
 websockets<14.0
 aiohttp-socks

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(exclude=["test", "systest"]),
     extras_require={},
     install_requires=[
-        "kafka-python<2.0.4",
+        "kafka-python<2.4.0",
         "requests",
         "websockets<14.0",
         "aiohttp-socks",


### PR DESCRIPTION
Update the version constraint from <2.0.4 to support latest 2.3.1 release.

kafka-python 2.2.0+ removed errors.RETRY_ERROR_TYPES in favor of per-class retriable attributes. Add _get_retriable_kafka_errors() helper that falls back to introspecting error classes when the legacy constant is unavailable, maintaining compatibility with both old and new versions.