### PR TITLE
Fix websockets compatibility for version 14+

### DIFF
--- a/journalpump/senders/websocket.py
+++ b/journalpump/senders/websocket.py
@@ -16,7 +16,7 @@ import snappy  # pylint: disable=import-error
 import socket
 import ssl
 import time
-import websockets.client
+import websockets.asyncio.client
 import websockets.exceptions
 
 
@@ -77,7 +77,7 @@ class WebsocketRunner(Thread):
 
         self.socks5_proxy = None
         if self.socks5_proxy_url:
-            self.socks5_proxy = Proxy.from_url(self.socks5_proxy_url, loop=self.websocket_loop)
+            self.socks5_proxy = Proxy.from_url(self.socks5_proxy_url)
 
     async def consumer_handler(self, websocket):
         # Dummy consumer to read and ignore messages from the websocket
@@ -179,15 +179,20 @@ class WebsocketRunner(Thread):
             )
 
         ws_compr = None if self.websocket_compression == WebsocketCompression.none else str(self.websocket_compression)
-        return await websockets.client.connect(  # pylint:disable=no-member
+        kwargs = {
+            "compression": ws_compr,
+            "additional_headers": headers,
+            "close_timeout": 20,
+            "max_size": MAX_KAFKA_MESSAGE_SIZE * 2,
+        }
+        if ssl_context is not None:
+            kwargs["ssl"] = ssl_context
+            kwargs["server_hostname"] = url_parsed.hostname
+        if sock is not None:
+            kwargs["sock"] = sock
+        return await websockets.asyncio.client.connect(
             self.websocket_uri,
-            ssl=ssl_context,
-            compression=ws_compr,
-            extra_headers=headers,
-            sock=sock,
-            server_hostname=url_parsed.hostname if self.ssl_enabled else None,
-            close_timeout=20,
-            max_size=MAX_KAFKA_MESSAGE_SIZE * 2,
+            **kwargs,
         )
 
     async def websocket_connect(self, *, timeout=30):
@@ -247,7 +252,7 @@ class WebsocketRunner(Thread):
                 task.cancel()
         except ConnectionRefusedError as ex:
             self.log.warning("Websocket connection refused: %r. Retrying.", ex)
-        except websockets.exceptions.InvalidStatusCode as ex:  # pylint: disable=no-member
+        except websockets.exceptions.InvalidStatus as ex:
             self.log.error(
                 "Websocket server rejected connection with HTTP status code: %r. Retrying.",
                 ex,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 kafka-python<2.4.0
 requests
-websockets<14.0
+websockets>=14.0
 aiohttp-socks
 python-snappy
 botocore

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         "kafka-python<2.4.0",
         "requests",
-        "websockets<14.0",
+        "websockets>=14.0",
         "aiohttp-socks",
         "python-snappy",
         "botocore",

--- a/test/test_websocket.py
+++ b/test/test_websocket.py
@@ -35,8 +35,8 @@ class WebsocketMockServer(threading.Thread):
             self.log.info("WS: Received message: %r", message)
             self.in_queue.append(message)
 
-    async def process_connection(self, websocket, path):
-        self.log.info("WS: Client connection accepted on %s", path)
+    async def process_connection(self, websocket):
+        self.log.info("WS: Client connection accepted")
         pending = set()
 
         try:
@@ -71,7 +71,6 @@ class WebsocketMockServer(threading.Thread):
             self.process_connection,
             "127.0.0.1",
             self.port,
-            loop=self.loop,
             ssl=ctx,
             close_timeout=10,
         ) as server:


### PR DESCRIPTION
Fix websockets compatibility for version 14+
    
Migrate from the deprecated websockets.legacy API to the new
websockets.asyncio API:
    
 - Use websockets.asyncio.client.connect instead of websockets.client.connect
 - Rename extra_headers to additional_headers
 - Remove deprecated loop parameter from websockets.serve() in tests
 - Remove deprecated path parameter from server handler in tests
 - Remove deprecated loop parameter from Proxy.from_url()
 - Only pass ssl/server_hostname kwargs when SSL is enabled
 - Pin websockets>=14.0 since the new asyncio API is required

Fedora 42 uses websockets 14.1