### PR TITLE
rsyslog: add opt-in escape_newlines option

### DIFF
--- a/journalpump/rsyslog.py
+++ b/journalpump/rsyslog.py
@@ -87,6 +87,7 @@ class SyslogTcpClient:
         certfile=None,
         log_format=None,
         octet_counted_framing=None,
+        escape_newlines=None,
     ):
         self.socket = None
         self.server = server
@@ -95,6 +96,7 @@ class SyslogTcpClient:
         self.socket_proto = socket.SOCK_STREAM
         self.ssl_context = None
         self.octet_counted_framing = False if octet_counted_framing is None else octet_counted_framing
+        self.escape_newlines = False if escape_newlines is None else escape_newlines
         if rfc == "RFC5424":
             self.formatter = _rfc_5424_formatter
         elif rfc == "RFC3164":
@@ -211,6 +213,8 @@ class SyslogTcpClient:
         proc_id = pid if pid else NILVALUE
         msg_id = msgid if msgid else NILVALUE
         message = msg if msg else NILVALUE
+        if self.escape_newlines:
+            message = message.replace("\r", "\\r").replace("\n", "\\n")
         rfc3164date = datetime.datetime.strptime(timestamp[:19], "%Y-%m-%dT%H:%M:%S").strftime("%b %d %H:%M:%S")
 
         self.send(

--- a/journalpump/senders/rsyslog.py
+++ b/journalpump/senders/rsyslog.py
@@ -47,6 +47,7 @@ class RsyslogSender(LogSender):
                     certfile=self.config.get("client_cert"),
                     log_format=self.config.get("logline"),
                     octet_counted_framing=self.config.get("octet_counted_framing"),
+                    escape_newlines=self.config.get("escape_newlines"),
                 )
                 self.log.info(
                     "Initialized Rsyslog Client %s, server: %s, port: %d",

--- a/systest/test_rsyslog.py
+++ b/systest/test_rsyslog.py
@@ -115,7 +115,7 @@ def _run_pump_test(
     logfile,
     messages_to_send,
     expected_message_count,
-    expected_multiline_support,
+    expected_info_line_ending: str | None = None,
     expected_subsequent_message=None,
 ):
     journalpump = None
@@ -156,7 +156,7 @@ def _run_pump_test(
 
     # Check the results
     found = 0
-    multiline_support = False
+    info_line = None
     subsequent_message_found = False
     with open(logfile, "r", encoding="utf-8") as fp:
         lines = fp.readlines()
@@ -167,7 +167,7 @@ def _run_pump_test(
                 log.info("Found: %s", line)
                 found += 1
                 if txt == "Info":
-                    multiline_support = line.endswith("example#012stack#012trace {%} -\n")
+                    info_line = line
                 break
     if expected_subsequent_message is not None:
         subsequent_pattern = re.compile(rf".*{expected_subsequent_message} for {identifier}.*")
@@ -180,13 +180,15 @@ def _run_pump_test(
             subsequent_message_found
         ), "Subsequent message not found — connection likely desynced after oversize octet-counted frame"
     assert found == expected_message_count, "Expected messages not found in syslog"
-    assert (
-        multiline_support == expected_multiline_support
-    ), f"Multi-line support is {multiline_support} which does not match expected {expected_multiline_support}"
+    if expected_info_line_ending is not None:
+        assert info_line is not None, "Info message not found in syslog"
+        assert info_line.endswith(
+            expected_info_line_ending
+        ), f"Info line ending mismatch: expected {expected_info_line_ending!r}, got {info_line!r}"
 
 
 @pytest.mark.parametrize(
-    "messages_to_send,sender_config,expected_message_count,expected_multiline_support,expected_subsequent_message",
+    "messages_to_send,sender_config,expected_message_count,expected_info_line_ending,expected_subsequent_message",
     [
         (
             [
@@ -203,7 +205,7 @@ def _run_pump_test(
             ],
             {},  # config not specified, octet_counted_framing is False by default
             4,
-            False,
+            None,
             None,
         ),
         (
@@ -215,7 +217,7 @@ def _run_pump_test(
             ],
             {"octet_counted_framing": False},
             1,
-            False,
+            None,
             None,
         ),
         (
@@ -227,7 +229,19 @@ def _run_pump_test(
             ],
             {"octet_counted_framing": True},
             1,
-            True,
+            "example#012stack#012trace {%} -\n",
+            None,
+        ),
+        (
+            [
+                {
+                    "text": "Info message for {identifier}\nexample\nstack\ntrace",
+                    "PRIORITY": journal.LOG_INFO,
+                },
+            ],
+            {"escape_newlines": True},
+            1,
+            "example\\nstack\\ntrace {%} -\n",
             None,
         ),
         # Verify that an oversize octet-counted frame is truncated without desyncing the stream.
@@ -243,9 +257,9 @@ def _run_pump_test(
                     "PRIORITY": journal.LOG_CRIT,
                 },
             ],
-            {"octet_counted_framing": True, "max_message_size": 80},
+            {"octet_counted_framing": True, "max_message_size": 200},
             2,
-            False,
+            None,
             "Critical message",
         ),
     ],
@@ -255,7 +269,7 @@ def test_rsyslogd_tcp_sender(
     messages_to_send,
     sender_config,
     expected_message_count,
-    expected_multiline_support,
+    expected_info_line_ending,
     expected_subsequent_message,
 ):
     workdir = tmpdir.dirname
@@ -289,7 +303,7 @@ def test_rsyslogd_tcp_sender(
             logfile=logfile,
             messages_to_send=messages_to_send,
             expected_message_count=expected_message_count,
-            expected_multiline_support=expected_multiline_support,
+            expected_info_line_ending=expected_info_line_ending,
             expected_subsequent_message=expected_subsequent_message,
         )
     finally:

--- a/test/test_rsyslog.py
+++ b/test/test_rsyslog.py
@@ -21,7 +21,9 @@ class _StubSocket:
         pass
 
 
-def _make_client(*, max_msg: int, octet_counted_framing: bool) -> tuple[SyslogTcpClient, _StubSocket]:
+def _make_client(
+    *, max_msg: int, octet_counted_framing: bool = False, escape_newlines: bool = False
+) -> tuple[SyslogTcpClient, _StubSocket]:
     with mock.patch.object(SyslogTcpClient, "_connect"):
         client = SyslogTcpClient(
             server="127.0.0.1",
@@ -29,6 +31,7 @@ def _make_client(*, max_msg: int, octet_counted_framing: bool) -> tuple[SyslogTc
             rfc="RFC5424",
             max_msg=max_msg,
             octet_counted_framing=octet_counted_framing,
+            escape_newlines=escape_newlines,
         )
     sock = _StubSocket()
     client.socket = sock
@@ -176,3 +179,31 @@ class TestOctetCountedFraming:
         frames = _parse_octet_counted_frames(bytes(sock.sent))
         assert len(frames) == 1
         assert len(frames[0]) <= max_msg
+
+
+class TestEscapeNewlines:
+    """escape_newlines=True escapes embedded CR/LF in the message before framing."""
+
+    def _log_multiline(self, *, escape_newlines: bool) -> bytes:
+        client, sock = _make_client(max_msg=4096, escape_newlines=escape_newlines)
+        client.log(
+            facility=1,
+            severity=6,
+            timestamp="2024-01-01T00:00:00.000000Z",
+            hostname="host",
+            program="app",
+            msg="line1\nline2\r\nline3",
+        )
+        return bytes(sock.sent)
+
+    def test_disabled_keeps_raw_newlines(self):
+        sent = self._log_multiline(escape_newlines=False)
+        assert sent == b"<14>1 2024-01-01T00:00:00.000000Z host app - - line1\nline2\r\nline3\n"
+
+    def test_enabled_escapes_newlines(self):
+        sent = self._log_multiline(escape_newlines=True)
+        assert sent == b"<14>1 2024-01-01T00:00:00.000000Z host app - - line1\\nline2\\r\\nline3\n"
+
+    def test_enabled_single_trailing_real_newline(self):
+        sent = self._log_multiline(escape_newlines=True)
+        assert sent.count(b"\n") == 1


### PR DESCRIPTION
Multi-line records (e.g. Java stack traces) sent to collectors, which
support only newline-delimited log intakes, are truncated to the first
line, because the intake treats each physical newline as a record
boundary.

Add `escape_newlines` (default false) to SyslogTcpClient. When
enabled, embedded `\r` and `\n` in the `MESSAGE` field are replaced with
literal `\r` and `\n` before formatting (`\\r`, and `\\n`), so the
framed record is one physical line terminated by a single trailing
newline.
