### PR TITLE
journalpump: Correct seek_tail reader positioning and harden rsyslog systests

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -471,6 +471,19 @@ class JournalReader(Tagged):
             self.read_next()
         elif self.initial_position == "tail":
             self.journald_reader.seek_tail()
+            # sd_journal_next() is not allowed immediately after sd_journal_seek_tail();
+            # call get_previous() first to land on the last entry, then read_next()
+            # to step past it and position at the true tail.
+            try:
+                self.journald_reader.get_previous()
+            except OSError as ex:
+                # A corrupt last entry can raise "Bad message" while materializing
+                # fields; the cursor has still advanced, so handle it like
+                # read_next() and carry on instead of failing reader init.
+                if "Bad message" not in str(ex):
+                    raise
+                self.stats.increase("journal.corrupted_log_entry", tags=self.make_tags())
+                self.log.warning("Corrupted log entry in %s", self.name)
             self.read_next()
         elif self.initial_position == "head":
             self.journald_reader.seek_head()

--- a/systest/test_rsyslog.py
+++ b/systest/test_rsyslog.py
@@ -243,7 +243,7 @@ def _run_pump_test(
                     "PRIORITY": journal.LOG_CRIT,
                 },
             ],
-            {"octet_counted_framing": True, "max_message_size": 80},
+            {"octet_counted_framing": True, "max_message_size": 200},
             2,
             False,
             "Critical message",
@@ -266,6 +266,7 @@ def test_rsyslogd_tcp_sender(
             {
                 "readers": {
                     "syslog-tcp": {
+                        "initial_position": "tail",
                         "senders": {
                             "rsyslog": {
                                 "output_type": "rsyslog",

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -1640,3 +1640,77 @@ def test_broken_reader(mocker, caplog):
     caplog.clear()
     journal_reader.create_journald_reader_if_missing()
     assert ["Corrupted log entry in foo"] == [r.message for r in caplog.records]
+
+
+def test_tail_initialization_steps_past_last_entry(mocker):
+    # sd_journal_next() is not allowed immediately after sd_journal_seek_tail();
+    # get_previous() must run first to land on the last entry, then read_next()
+    # steps past it to the true tail.
+    calls = []
+    journal_reader = JournalReader(
+        name="foo",
+        config={"senders": {}},
+        field_filters={},
+        geoip=None,
+        stats=mock.Mock(),
+        initial_position="tail",
+        searches=[],
+    )
+
+    mocker.patch.object(PumpReader, "has_persistent_files", return_value=True)
+    mocker.patch.object(PumpReader, "seek_tail", side_effect=lambda: calls.append("seek_tail"))
+    mocker.patch.object(PumpReader, "get_previous", side_effect=lambda: calls.append("get_previous"))
+    mocker.patch.object(JournalReader, "read_next", side_effect=lambda: calls.append("read_next"))
+
+    journal_reader.create_journald_reader_if_missing()
+
+    assert calls == ["seek_tail", "get_previous", "read_next"]
+
+
+def test_tail_initialization_tolerates_corrupt_last_entry(mocker, caplog):
+    # A corrupt last entry can raise "Bad message" while get_previous() materializes
+    # its fields; reader init must swallow it and still position at the tail.
+    stats = mock.Mock()
+    journal_reader = JournalReader(
+        name="foo",
+        config={"senders": {}},
+        field_filters={},
+        geoip=None,
+        stats=stats,
+        initial_position="tail",
+        searches=[],
+    )
+
+    mocker.patch.object(PumpReader, "has_persistent_files", return_value=True)
+    mocker.patch.object(PumpReader, "seek_tail")
+    mocker.patch.object(PumpReader, "get_previous", side_effect=OSError("Bad message"))
+    read_next = mocker.patch.object(JournalReader, "read_next")
+
+    caplog.clear()
+    journal_reader.create_journald_reader_if_missing()
+
+    assert journal_reader.journald_reader is not None
+    read_next.assert_called_once()
+    assert "Corrupted log entry in foo" in [r.message for r in caplog.records]
+    stats.increase.assert_any_call("journal.corrupted_log_entry", tags=mock.ANY)
+
+
+def test_tail_initialization_reraises_unexpected_oserror(mocker):
+    # Only "Bad message" is tolerated; any other OSError must propagate.
+    journal_reader = JournalReader(
+        name="foo",
+        config={"senders": {}},
+        field_filters={},
+        geoip=None,
+        stats=mock.Mock(),
+        initial_position="tail",
+        searches=[],
+    )
+
+    mocker.patch.object(PumpReader, "has_persistent_files", return_value=True)
+    mocker.patch.object(PumpReader, "seek_tail")
+    mocker.patch.object(PumpReader, "get_previous", side_effect=OSError("input/output error"))
+    mocker.patch.object(JournalReader, "read_next")
+
+    with pytest.raises(OSError, match="input/output error"):
+        journal_reader.create_journald_reader_if_missing()


### PR DESCRIPTION
The journal reader's seek_tail code path called `sd_journal_next()`
immediately after `sd_journal_seek_tail()`, violating the API contract.
Per the systemd man page, `sd_journal_previous()` must be called first
to land on a real entry before stepping past it. Without this, the
inotify fd was never armed and new journal entries were silently missed.

ref: https://www.man7.org/linux/man-pages/man3/sd_journal_next.3.html

The rsyslog systests had two issues that masked this bug and caused
failures on machines with a large journal. Readers with no
`initial_position` defaulted to head, flooding the sender buffer with
old entries before test messages could arrive. The oversize-frame test
used `max_message_size` 80, which truncated message bodies before the
identifier on long-hostname machines. Both are fixed in the test config.
