### PR TITLE
journalpump: replace deprecated datetime.utcnow/utcfromtimestamp calls

### DIFF
--- a/journalpump/journalpump.py
+++ b/journalpump/journalpump.py
@@ -757,9 +757,11 @@ class JournalObjectHandler:
 
         # Always set a timestamp field that gets turned into an ISO timestamp based on REALTIME_TIMESTAMP if available
         if "REALTIME_TIMESTAMP" in data:
-            timestamp = datetime.datetime.utcfromtimestamp(data["REALTIME_TIMESTAMP"])
+            timestamp = datetime.datetime.fromtimestamp(data["REALTIME_TIMESTAMP"], datetime.timezone.utc).replace(
+                tzinfo=None
+            )
         else:
-            timestamp = datetime.datetime.utcnow()
+            timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         data["timestamp"] = timestamp
 
         if extra_field_values:
@@ -836,7 +838,7 @@ class JournalPump(ServiceDaemon, Tagged):
         self.previous_state = None
         self.last_state_save_time = time.monotonic()
         ServiceDaemon.__init__(self, config_path=config_path, multi_threaded=True, log_level=logging.INFO)
-        self.start_time_str = datetime.datetime.utcnow().isoformat()
+        self.start_time_str = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
         self.configure_field_filters()
         self.configure_unit_log_levels()
         self.configure_readers()

--- a/test/test_journalpump.py
+++ b/test/test_journalpump.py
@@ -1,7 +1,7 @@
 from .data import GCP_PRIVATE_KEY
 from botocore.stub import Stubber
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from journalpump import senders
 from journalpump.journalpump import (
     _5_MB,
@@ -975,7 +975,7 @@ class TestJournalObjectHandler(TestCase):
                 b=2,
                 c=3,
                 REALTIME_TIMESTAMP=1,
-                timestamp=datetime.utcfromtimestamp(1),
+                timestamp=datetime.fromtimestamp(1, timezone.utc).replace(tzinfo=None),
             ),
             default=default_json_serialization,
         ).encode("utf-8")


### PR DESCRIPTION
Python 3.12+ emits DeprecationWarnings for these APIs, and they showed
up in our 3.14 CI runs. We swapped them for timezone-aware UTC
equivalents:

* `utcnow()` -> `now(timezone.utc)`
* `utcfromtimestamp()` → `fromtimestamp(..., timezone.utc)`

Naive UTC output is preserved via `.replace(tzinfo=None)` so downstream
timestamp formatting stays the same.
